### PR TITLE
feat: [W-000004] Handle invalid city URL params gracefully

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -153,8 +153,32 @@ test.describe('Error Handling', () => {
   test('handles invalid city ID in URL gracefully', async ({ page }) => {
     await page.goto('/?city=invalid-city')
 
-    // Invalid city should not open panel
-    await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 })
+    // Invalid city should open panel with error view
+    await expect(page.locator('.weather-panel.open')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('heading', { name: 'City not supported' })).toBeVisible()
+    await expect(page.getByText(/invalid-city/)).toBeVisible()
+  })
+
+  test('invalid city view shows Return Home button that navigates to /', async ({ page }) => {
+    await page.goto('/?city=nope')
+
+    await expect(page.locator('.weather-panel.open')).toBeVisible({ timeout: 10000 })
+
+    await page.getByRole('button', { name: 'Return Home' }).click()
+
+    await expect(page.locator('.weather-panel.open')).not.toBeVisible({ timeout: 5000 })
+    await expect(page).toHaveURL('/')
+  })
+
+  test('invalid city view allows selecting a valid city', async ({ page }) => {
+    await page.goto('/?city=nope')
+
+    await expect(page.getByRole('heading', { name: 'City not supported' })).toBeVisible({ timeout: 10000 })
+
+    await page.locator('.city-picker-select').selectOption('tokyo')
+
+    await expect(page.locator('.dashboard-header')).toBeVisible({ timeout: 15000 })
+    await expect(page).toHaveURL(/\?city=tokyo/)
   })
 
   test('shows map error when Mapbox token is rejected', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,23 +5,10 @@ import { InvalidCityView } from './components/InvalidCityView'
 import { PanelSkeleton } from './components/PanelSkeleton'
 import { useWeather } from './hooks/useWeather'
 import { CITIES, DEFAULT_CITY, type City } from './types'
+import { getCityFromURL } from './utils/cityUrl'
 import './App.css'
 
 const Dashboard = lazy(() => import('./components/Dashboard').then((m) => ({ default: m.Dashboard })))
-
-export interface CityURLResult {
-  city: City | null
-  invalidId: string | null
-}
-
-export function getCityFromURL(): CityURLResult {
-  const params = new URLSearchParams(window.location.search)
-  const cityId = params.get('city')
-  if (!cityId) return { city: null, invalidId: null }
-  const found = CITIES.find((c) => c.id === cityId)
-  if (found) return { city: found, invalidId: null }
-  return { city: null, invalidId: cityId }
-}
 
 function App() {
   const [selectedCity, setSelectedCity] = useState<City | null>(() => getCityFromURL().city)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef, lazy, Suspense } from 'react'
 import { MapView } from './components/MapView'
 import { WeatherPanel } from './components/WeatherPanel'
+import { InvalidCityView } from './components/InvalidCityView'
 import { PanelSkeleton } from './components/PanelSkeleton'
 import { useWeather } from './hooks/useWeather'
 import { CITIES, DEFAULT_CITY, type City } from './types'
@@ -8,15 +9,23 @@ import './App.css'
 
 const Dashboard = lazy(() => import('./components/Dashboard').then((m) => ({ default: m.Dashboard })))
 
-function getCityFromURL(): City | null {
+export interface CityURLResult {
+  city: City | null
+  invalidId: string | null
+}
+
+export function getCityFromURL(): CityURLResult {
   const params = new URLSearchParams(window.location.search)
   const cityId = params.get('city')
-  if (!cityId) return null
-  return CITIES.find((c) => c.id === cityId) ?? null
+  if (!cityId) return { city: null, invalidId: null }
+  const found = CITIES.find((c) => c.id === cityId)
+  if (found) return { city: found, invalidId: null }
+  return { city: null, invalidId: cityId }
 }
 
 function App() {
-  const [selectedCity, setSelectedCity] = useState<City | null>(getCityFromURL)
+  const [selectedCity, setSelectedCity] = useState<City | null>(() => getCityFromURL().city)
+  const [invalidCityId, setInvalidCityId] = useState<string | null>(() => getCityFromURL().invalidId)
   const announcement = useMemo(() => selectedCity ? `${selectedCity.name} selected, weather panel opened` : '', [selectedCity])
   const markerRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const lastSelectedRef = useRef<string | null>(null)
@@ -25,13 +34,18 @@ function App() {
 
   // Sync URL → state on popstate (back/forward)
   useEffect(() => {
-    const onPopState = () => setSelectedCity(getCityFromURL())
+    const onPopState = () => {
+      const result = getCityFromURL()
+      setSelectedCity(result.city)
+      setInvalidCityId(result.invalidId)
+    }
     window.addEventListener('popstate', onPopState)
     return () => window.removeEventListener('popstate', onPopState)
   }, [])
 
   const selectCity = useCallback((city: City | null) => {
     setSelectedCity(city)
+    setInvalidCityId(null)
     const url = city ? `/?city=${city.id}` : '/'
     window.history.pushState({}, '', url)
   }, [])
@@ -59,19 +73,31 @@ function App() {
         onDeselect={handlePanelClose}
         markerRefs={markerRefs}
       />
-      <WeatherPanel isOpen={selectedCity !== null} onClose={handlePanelClose} cityName={selectedCity?.name}>
-        <Suspense fallback={<PanelSkeleton />}>
-          <Dashboard
-            current={current}
-            forecast={forecast}
-            isLoading={isLoading}
-            error={error}
-            source={source}
-            onRetry={refetch}
-            city={activeCity}
+      <WeatherPanel
+        isOpen={selectedCity !== null || invalidCityId !== null}
+        onClose={handlePanelClose}
+        cityName={invalidCityId ? 'Unknown City' : selectedCity?.name}
+      >
+        {invalidCityId ? (
+          <InvalidCityView
+            invalidCityId={invalidCityId}
+            onGoHome={handlePanelClose}
             onCityChange={(city) => selectCity(city)}
           />
-        </Suspense>
+        ) : (
+          <Suspense fallback={<PanelSkeleton />}>
+            <Dashboard
+              current={current}
+              forecast={forecast}
+              isLoading={isLoading}
+              error={error}
+              source={source}
+              onRetry={refetch}
+              city={activeCity}
+              onCityChange={(city) => selectCity(city)}
+            />
+          </Suspense>
+        )}
       </WeatherPanel>
       <div className="sr-only" aria-live="polite" role="status">
         {announcement}

--- a/src/components/InvalidCityView.css
+++ b/src/components/InvalidCityView.css
@@ -1,0 +1,36 @@
+.invalid-city-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  text-align: center;
+}
+
+.invalid-city-state h2 {
+  margin: 0 0 8px;
+  color: var(--text-h);
+}
+
+.invalid-city-state p {
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.invalid-city-id {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.invalid-city-hint {
+  margin-bottom: 24px !important;
+  font-size: 14px;
+  opacity: 0.8;
+}
+
+.invalid-city-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}

--- a/src/components/InvalidCityView.test.tsx
+++ b/src/components/InvalidCityView.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { InvalidCityView } from './InvalidCityView'
+import { CITIES } from '../types'
+
+describe('InvalidCityView', () => {
+  it('renders heading and invalid city ID', () => {
+    render(<InvalidCityView invalidCityId="foobar" onGoHome={vi.fn()} onCityChange={vi.fn()} />)
+
+    expect(screen.getByRole('heading', { name: 'City not supported' })).toBeInTheDocument()
+    expect(screen.getByText(/foobar/)).toBeInTheDocument()
+  })
+
+  it('calls onGoHome when Return Home button is clicked', () => {
+    const onGoHome = vi.fn()
+    render(<InvalidCityView invalidCityId="xyz" onGoHome={onGoHome} onCityChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Return Home' }))
+    expect(onGoHome).toHaveBeenCalledOnce()
+  })
+
+  it('renders a city picker and calls onCityChange when a city is selected', () => {
+    const onCityChange = vi.fn()
+    render(<InvalidCityView invalidCityId="xyz" onGoHome={vi.fn()} onCityChange={onCityChange} />)
+
+    const select = screen.getByRole('combobox')
+    expect(select).toBeInTheDocument()
+
+    fireEvent.change(select, { target: { value: 'tokyo' } })
+    const tokyo = CITIES.find((c) => c.id === 'tokyo')!
+    expect(onCityChange).toHaveBeenCalledWith(tokyo)
+  })
+
+  it('sanitises the city ID as text content only', () => {
+    const xss = '<script>alert("xss")</script>'
+    render(<InvalidCityView invalidCityId={xss} onGoHome={vi.fn()} onCityChange={vi.fn()} />)
+
+    expect(screen.queryByText('alert("xss")', { exact: false })).toBeInTheDocument()
+    expect(document.querySelector('script')).toBeNull()
+  })
+})

--- a/src/components/InvalidCityView.tsx
+++ b/src/components/InvalidCityView.tsx
@@ -1,0 +1,29 @@
+import { CityPicker } from './CityPicker'
+import { DEFAULT_CITY, type City } from '../types'
+import './InvalidCityView.css'
+
+interface InvalidCityViewProps {
+  invalidCityId: string
+  onGoHome: () => void
+  onCityChange: (city: City) => void
+}
+
+export function InvalidCityView({ invalidCityId, onGoHome, onCityChange }: InvalidCityViewProps) {
+  return (
+    <div className="dashboard">
+      <div className="invalid-city-state">
+        <h2>City not supported</h2>
+        <p>
+          The city "<span className="invalid-city-id">{invalidCityId}</span>" is not available.
+        </p>
+        <p className="invalid-city-hint">Select a supported city below or return to the map.</p>
+        <div className="invalid-city-actions">
+          <CityPicker selectedCity={DEFAULT_CITY} onCityChange={onCityChange} />
+          <button className="retry-button" onClick={onGoHome}>
+            Return Home
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/getCityFromURL.test.ts
+++ b/src/getCityFromURL.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getCityFromURL } from './App'
+import { CITIES } from './types'
+
+function setURL(search: string) {
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, search },
+    writable: true,
+  })
+}
+
+describe('getCityFromURL', () => {
+  afterEach(() => setURL(''))
+
+  it('returns null city and null invalidId when no param', () => {
+    setURL('')
+    expect(getCityFromURL()).toEqual({ city: null, invalidId: null })
+  })
+
+  it('returns the matching city when param is valid', () => {
+    setURL('?city=tokyo')
+    const result = getCityFromURL()
+    expect(result.city).toEqual(CITIES.find((c) => c.id === 'tokyo'))
+    expect(result.invalidId).toBeNull()
+  })
+
+  it('returns null city and the raw id when param is invalid', () => {
+    setURL('?city=atlantis')
+    const result = getCityFromURL()
+    expect(result.city).toBeNull()
+    expect(result.invalidId).toBe('atlantis')
+  })
+})

--- a/src/getCityFromURL.test.ts
+++ b/src/getCityFromURL.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { getCityFromURL } from './App'
+import { getCityFromURL } from './utils/cityUrl'
 import { CITIES } from './types'
 
 function setURL(search: string) {

--- a/src/utils/cityUrl.ts
+++ b/src/utils/cityUrl.ts
@@ -1,0 +1,15 @@
+import { CITIES, type City } from '../types'
+
+export interface CityURLResult {
+  city: City | null
+  invalidId: string | null
+}
+
+export function getCityFromURL(): CityURLResult {
+  const params = new URLSearchParams(window.location.search)
+  const cityId = params.get('city')
+  if (!cityId) return { city: null, invalidId: null }
+  const found = CITIES.find((c) => c.id === cityId)
+  if (found) return { city: found, invalidId: null }
+  return { city: null, invalidId: cityId }
+}


### PR DESCRIPTION
## Summary

Adds a recovery UI when users visit a URL with an unsupported `?city=` parameter. Instead of silently falling back to Atlanta, the app now opens the weather panel with a "City not supported" message, showing the invalid ID and offering a city picker + Return Home button.

## Changes

- **`src/App.tsx`** — `getCityFromURL()` returns discriminated `{ city, invalidId }` result; new `invalidCityId` state; popstate handles valid↔invalid transitions
- **`src/components/InvalidCityView.tsx`** — New component with heading, inline city picker, and Return Home button
- **`src/components/InvalidCityView.css`** — Scoped styles matching existing error-state patterns
- **`e2e/app.spec.ts`** — Updated existing invalid-city test + 2 new E2E tests

## Tests

- 114 unit tests passing (7 new)
- 3 new E2E tests: invalid city panel, Return Home navigation, city picker recovery

Closes #4