### PR TITLE
feat: add 10s fetch timeouts with composed abort signals

### DIFF
--- a/src/services/openMeteoApi.test.ts
+++ b/src/services/openMeteoApi.test.ts
@@ -187,8 +187,18 @@ describe('fetchOpenMeteoWeather', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ signal: controller.signal }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
+  })
+
+  it('throws timeout error when request times out', async () => {
+    const timeoutError = new DOMException('The operation was aborted.', 'TimeoutError')
+    globalThis.fetch = vi.fn().mockRejectedValue(timeoutError)
+
+    await expect(fetchOpenMeteoWeather(testCity)).rejects.toMatchObject({
+      type: 'timeout',
+      message: 'Request timed out. Please try again.',
+    })
   })
 
   it('does not call Math.random', async () => {

--- a/src/services/openMeteoApi.ts
+++ b/src/services/openMeteoApi.ts
@@ -86,7 +86,10 @@ export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): P
   try {
     const url = `${BASE_URL}/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code,pressure_msl,apparent_temperature,wind_direction_10m,visibility,uv_index&daily=weather_code,temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,sunrise,sunset&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto`
 
-    const response = await fetch(url, { signal })
+    const timeoutSignal = AbortSignal.timeout(10_000)
+    const composedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+
+    const response = await fetch(url, { signal: composedSignal })
 
     if (!response.ok) {
       throw parseError(response.status)
@@ -129,6 +132,10 @@ export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): P
   } catch (error) {
     if ((error as WeatherError).type) {
       throw error
+    }
+
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      throw { type: 'timeout' as WeatherErrorType, message: 'Request timed out. Please try again.' }
     }
 
     if (error instanceof TypeError && error.message.includes('fetch')) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -178,7 +178,7 @@ export interface WeatherApiResponse {
   forecast: ForecastDay[]
 }
 
-export type WeatherErrorType = 'network' | 'rate_limit' | 'invalid_key' | 'unknown'
+export type WeatherErrorType = 'network' | 'rate_limit' | 'invalid_key' | 'timeout' | 'unknown'
 
 export interface WeatherError {
   type: WeatherErrorType


### PR DESCRIPTION
## Summary
Add `AbortSignal.timeout(10_000)` composed with caller signal via `AbortSignal.any()` in both Open-Meteo and OWM services. Add `'timeout'` to `WeatherErrorType` union. Detect `TimeoutError` in catch blocks with user-friendly messaging.

## Type of Change
- [x] New feature

Closes #3