### PR TITLE
feat: respect prefers-reduced-motion and improve overlay contrast

### DIFF
--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -24,8 +24,8 @@
   bottom: 0;
   background: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 0.55),
-    rgba(255, 255, 255, 0.7)
+    rgba(255, 255, 255, 0.75),
+    rgba(255, 255, 255, 0.85)
   );
   z-index: -1;
   backdrop-filter: saturate(1.2);
@@ -35,8 +35,8 @@
   .dashboard-overlay {
     background: linear-gradient(
       to bottom,
-      rgba(18, 18, 22, 0.55),
-      rgba(18, 18, 22, 0.7)
+      rgba(18, 18, 22, 0.75),
+      rgba(18, 18, 22, 0.85)
     );
   }
 }

--- a/src/components/MapView.css
+++ b/src/components/MapView.css
@@ -64,6 +64,8 @@
 .map-marker:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.9), 0 0 0 6px var(--accent);
+  border-radius: 4px;
 }
 
 .marker-pulse {
@@ -93,5 +95,16 @@
 @media (prefers-color-scheme: dark) {
   .marker-label {
     background: rgba(26, 27, 33, 0.9);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marker-dot {
+    transition: none;
+  }
+
+  .marker-pulse {
+    animation: none;
+    display: none;
   }
 }

--- a/src/components/WeatherBackground.css
+++ b/src/components/WeatherBackground.css
@@ -187,3 +187,25 @@
   0%, 100% { background-position: 0 0; }
   50% { background-position: 0 100%; }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-bg-blob {
+    animation: none;
+    opacity: 1;
+  }
+
+  .blob-1,
+  .blob-2,
+  .blob-3 {
+    animation: none;
+    opacity: 1;
+  }
+
+  .weather-rain::after,
+  .weather-snow::after,
+  .weather-storm::after,
+  .weather-fog::after,
+  .weather-hot::after {
+    animation: none;
+  }
+}

--- a/src/components/WeatherPanel.css
+++ b/src/components/WeatherPanel.css
@@ -128,3 +128,13 @@
     height: 100vh;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-panel {
+    transition: none;
+  }
+
+  .weather-panel-backdrop {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
Add `@media (prefers-reduced-motion: reduce)` to WeatherBackground.css, MapView.css, and WeatherPanel.css. Increase dashboard overlay opacity to 0.75/0.85 for WCAG AA contrast.

## Type of Change
- [x] New feature

Closes #9