### PR TITLE
feat: add accessible summaries and sr-only data tables for charts

### DIFF
--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -104,7 +104,7 @@ describe('Dashboard', () => {
     )
 
     expect(screen.getByText('Temperature')).toBeInTheDocument()
-    expect(screen.getByText('Humidity')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Humidity' })).toBeInTheDocument()
     expect(screen.getByText('Wind Speed')).toBeInTheDocument()
     expect(screen.getByText('UV Index')).toBeInTheDocument()
   })
@@ -125,7 +125,7 @@ describe('Dashboard', () => {
     )
 
     expect(screen.getByText('Temperature')).toBeInTheDocument()
-    expect(screen.getByText('Humidity')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Humidity' })).toBeInTheDocument()
     expect(screen.getByText('Wind Speed')).toBeInTheDocument()
     expect(screen.queryByText('UV Index')).not.toBeInTheDocument()
   })
@@ -228,5 +228,59 @@ describe('Dashboard', () => {
     expect(screen.getByText('22')).toBeInTheDocument()
     expect(screen.getByText('km/h')).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: '°C' })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('charts section has aria-label', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        isLoading={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText('Forecast Charts')).toBeInTheDocument()
+  })
+
+  it('chart wrappers have role="img" and aria-label', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        isLoading={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    const chartImages = screen.getAllByRole('img')
+    expect(chartImages.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('provides sr-only data tables for charts', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        isLoading={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Temperature Trend Data')).toBeInTheDocument()
+    expect(screen.getByText('Conditions Distribution Data')).toBeInTheDocument()
+    expect(screen.getByText('Humidity Forecast Data')).toBeInTheDocument()
   })
 })

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { CityPicker } from './CityPicker'
 import { UnitToggle } from './UnitToggle'
 import { PanelSkeleton } from './PanelSkeleton'
 import { getStoredUnits, setStoredUnits, convertTemp, convertWindSpeed, convertVisibility, tempUnit, speedUnit, distanceUnit, type UnitSystem } from '../utils/units'
+import { temperatureSummary, conditionsSummary, humiditySummary } from '../utils/chartSummaries'
 import './Dashboard.css'
 
 ChartJS.register(
@@ -278,27 +279,54 @@ export function Dashboard({ current, forecast, isLoading, error, source, onRetry
         ))}
       </section>
 
-      <section className="charts-section">
+      <section className="charts-section" aria-label="Forecast Charts">
         <div className="chart-container large">
           <h2>Temperature Trend</h2>
-          <div className="chart-wrapper">
+          <div className="chart-wrapper" role="img" aria-label={temperatureSummary(forecast, tempUnit(units))}>
             {temperatureChartData && <Line data={temperatureChartData} options={chartOptions} />}
           </div>
+          <table className="sr-only">
+            <caption>Temperature Trend Data</caption>
+            <thead><tr><th>Date</th><th>High</th><th>Low</th></tr></thead>
+            <tbody>
+              {forecast.map((d) => (
+                <tr key={d.date}><td>{d.date}</td><td>{convertTemp(d.tempHigh, units)}{tempUnit(units)}</td><td>{convertTemp(d.tempLow, units)}{tempUnit(units)}</td></tr>
+              ))}
+            </tbody>
+          </table>
         </div>
 
         <div className="chart-row">
           <div className="chart-container">
             <h2>Conditions Distribution</h2>
-            <div className="chart-wrapper">
+            <div className="chart-wrapper" role="img" aria-label={conditionsSummary(forecast)}>
               {conditionsChartData && <Pie data={conditionsChartData} options={pieOptions} />}
             </div>
+            <table className="sr-only">
+              <caption>Conditions Distribution Data</caption>
+              <thead><tr><th>Date</th><th>Conditions</th></tr></thead>
+              <tbody>
+                {forecast.map((d) => (
+                  <tr key={d.date}><td>{d.date}</td><td>{d.conditions}</td></tr>
+                ))}
+              </tbody>
+            </table>
           </div>
 
           <div className="chart-container">
             <h2>Humidity Forecast</h2>
-            <div className="chart-wrapper">
+            <div className="chart-wrapper" role="img" aria-label={humiditySummary(forecast)}>
               {humidityChartData && <Bar data={humidityChartData} options={chartOptions} />}
             </div>
+            <table className="sr-only">
+              <caption>Humidity Forecast Data</caption>
+              <thead><tr><th>Date</th><th>Humidity</th></tr></thead>
+              <tbody>
+                {forecast.map((d) => (
+                  <tr key={d.date}><td>{d.date}</td><td>{d.humidity}%</td></tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       </section>

--- a/src/utils/chartSummaries.test.ts
+++ b/src/utils/chartSummaries.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { temperatureSummary, conditionsSummary, humiditySummary } from './chartSummaries'
+import type { ForecastDay } from '../types'
+
+const mockForecast: ForecastDay[] = [
+  { date: 'Thu Mar 13', tempHigh: 75, tempLow: 55, humidity: 60, conditions: 'Clear', conditionIcon: '01d' },
+  { date: 'Fri Mar 14', tempHigh: 78, tempLow: 58, humidity: 55, conditions: 'Clouds', conditionIcon: '03d' },
+  { date: 'Sat Mar 15', tempHigh: 80, tempLow: 60, humidity: 50, conditions: 'Clear', conditionIcon: '01d' },
+]
+
+describe('temperatureSummary', () => {
+  it('generates summary with temp range', () => {
+    const result = temperatureSummary(mockForecast, '°F')
+    expect(result).toContain('3 days')
+    expect(result).toContain('75°F')
+    expect(result).toContain('80°F')
+    expect(result).toContain('55°F')
+    expect(result).toContain('60°F')
+  })
+
+  it('returns fallback for empty forecast', () => {
+    expect(temperatureSummary([], '°F')).toBe('No forecast data available.')
+  })
+})
+
+describe('conditionsSummary', () => {
+  it('generates summary with condition counts', () => {
+    const result = conditionsSummary(mockForecast)
+    expect(result).toContain('2 days Clear')
+    expect(result).toContain('1 day Clouds')
+  })
+
+  it('returns fallback for empty forecast', () => {
+    expect(conditionsSummary([])).toBe('No forecast data available.')
+  })
+})
+
+describe('humiditySummary', () => {
+  it('generates summary with humidity range', () => {
+    const result = humiditySummary(mockForecast)
+    expect(result).toContain('3 days')
+    expect(result).toContain('50%')
+    expect(result).toContain('60%')
+  })
+
+  it('returns fallback for empty forecast', () => {
+    expect(humiditySummary([])).toBe('No forecast data available.')
+  })
+})

--- a/src/utils/chartSummaries.ts
+++ b/src/utils/chartSummaries.ts
@@ -1,0 +1,26 @@
+import type { ForecastDay } from '../types'
+
+export function temperatureSummary(forecast: ForecastDay[], unitLabel: string): string {
+  if (forecast.length === 0) return 'No forecast data available.'
+  const highs = forecast.map((d) => d.tempHigh)
+  const lows = forecast.map((d) => d.tempLow)
+  return `Temperature trend over ${forecast.length} days: highs from ${Math.min(...highs)}${unitLabel} to ${Math.max(...highs)}${unitLabel}, lows from ${Math.min(...lows)}${unitLabel} to ${Math.max(...lows)}${unitLabel}.`
+}
+
+export function conditionsSummary(forecast: ForecastDay[]): string {
+  if (forecast.length === 0) return 'No forecast data available.'
+  const counts: Record<string, number> = {}
+  forecast.forEach((d) => {
+    counts[d.conditions] = (counts[d.conditions] || 0) + 1
+  })
+  const parts = Object.entries(counts)
+    .map(([condition, count]) => `${count} day${count > 1 ? 's' : ''} ${condition}`)
+    .join(', ')
+  return `Conditions distribution: ${parts}.`
+}
+
+export function humiditySummary(forecast: ForecastDay[]): string {
+  if (forecast.length === 0) return 'No forecast data available.'
+  const humidities = forecast.map((d) => d.humidity)
+  return `Humidity forecast over ${forecast.length} days: ranging from ${Math.min(...humidities)}% to ${Math.max(...humidities)}%.`
+}


### PR DESCRIPTION
## Summary
Add `aria-label="Forecast Charts"` to the charts section. Each chart wrapper gets `role="img"` with a generated summary aria-label. Add sr-only HTML data tables as screen reader alternatives. New `chartSummaries.ts` utility with unit tests.

## Type of Change
- [x] New feature

Closes #10