### PR TITLE
feat: improve keyboard accessibility for city markers

### DIFF
--- a/src/components/MapView.test.tsx
+++ b/src/components/MapView.test.tsx
@@ -34,7 +34,7 @@ describe('MapView', () => {
   it('selected marker has aria-pressed true', () => {
     render(<MapView selectedCityId="atlanta" onCitySelect={vi.fn()} />)
 
-    const marker = screen.getByRole('button', { name: 'Atlanta, US' })
+    const marker = screen.getByRole('button', { name: 'Atlanta, US — selected' })
     expect(marker).toHaveAttribute('aria-pressed', 'true')
     expect(marker.className).toContain('selected')
   })
@@ -85,5 +85,19 @@ describe('MapView', () => {
     for (const city of CITIES_FOR_MARKERS) {
       expect(screen.getByText(city.name)).toBeInTheDocument()
     }
+  })
+
+  it('enriches aria-label with selected state', () => {
+    render(<MapView selectedCityId="atlanta" onCitySelect={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Atlanta, US — selected' })).toBeInTheDocument()
+  })
+
+  it('non-selected markers do not include selected in aria-label', () => {
+    render(<MapView selectedCityId="atlanta" onCitySelect={vi.fn()} />)
+
+    const londonMarker = screen.getByRole('button', { name: 'London, GB' })
+    expect(londonMarker).toBeInTheDocument()
+    expect(londonMarker.getAttribute('aria-label')).not.toContain('selected')
   })
 })

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -190,6 +190,7 @@ function CityMarker({ city, isSelected, onClick, markerRef }: CityMarkerProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
+      e.stopPropagation()
       onClick()
     }
   }
@@ -200,7 +201,7 @@ function CityMarker({ city, isSelected, onClick, markerRef }: CityMarkerProps) {
       className={`map-marker ${isSelected ? 'selected' : ''}`}
       role="button"
       tabIndex={0}
-      aria-label={`${city.name}, ${city.country}`}
+      aria-label={`${city.name}, ${city.country}${isSelected ? ' — selected' : ''}`}
       aria-pressed={isSelected}
       onClick={(e) => {
         e.stopPropagation()


### PR DESCRIPTION
## Summary
Add `stopPropagation` to keyDown handler to prevent map click handler from firing on keyboard activation. Enrich `aria-label` with '— selected' state context. Add tests for enriched aria-labels.

Note: Double-ring focus style (`box-shadow` + `outline`) is in #56 (MapView.css changes).

## Type of Change
- [x] New feature

Closes #11