### PR TITLE
feat: rework weather panel for mobile-first layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>performance-teardown-demo</title>
   </head>
   <body>

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -224,6 +224,12 @@
   }
 }
 
+@media (max-width: 768px) {
+  .chart-container {
+    padding: 16px;
+  }
+}
+
 @media (max-width: 640px) {
   .dashboard {
     padding: 16px;
@@ -235,6 +241,10 @@
 
   .dashboard-header h1 {
     font-size: 24px;
+  }
+
+  .chart-wrapper {
+    height: 200px;
   }
 
   .additional-info {

--- a/src/components/WeatherPanel.css
+++ b/src/components/WeatherPanel.css
@@ -115,7 +115,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    height: 50vh;
+    height: 60vh;
     border-radius: 16px 16px 0 0;
     transform: translateY(100%);
   }
@@ -126,6 +126,19 @@
 
   .weather-panel.expanded {
     height: 100vh;
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
+  .weather-panel-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg);
+    padding: 8px 16px 12px;
+  }
+
+  .weather-panel-body {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
   }
 }
 


### PR DESCRIPTION
## Summary
Improve mobile experience with viewport-fit=cover, 60vh panel height, sticky header, safe-area insets, and reduced chart heights on small screens.

## Changes
- `index.html`: Add `viewport-fit=cover` to meta viewport
- `src/components/WeatherPanel.css`: Sticky header, safe-area padding, 60vh height
- `src/components/Dashboard.css`: Reduced chart height on mobile

## Testing
- CSS-only changes (no new unit tests needed)
- 137 total tests passing

## Related Issue
Closes #17