### PR TITLE
feat: add next-24-hours hourly forecast section

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -94,6 +94,15 @@ test.describe('Weather Panel Content', () => {
     await expect(page.getByRole('heading', { name: 'Wind Speed', exact: true })).toBeVisible()
   })
 
+  test('displays hourly forecast section', async ({ page }) => {
+    await page.goto('/?city=atlanta')
+
+    await expect(page.locator('.hourly-forecast')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByRole('heading', { name: 'Next 24 Hours' })).toBeVisible()
+    // Should have at least one hourly item
+    await expect(page.locator('.hourly-item').first()).toBeVisible()
+  })
+
   test('displays chart sections', async ({ page }) => {
     await page.goto('/?city=atlanta')
 

--- a/e2e/fixtures/weather.ts
+++ b/e2e/fixtures/weather.ts
@@ -1,5 +1,19 @@
 import type { Page } from '@playwright/test'
 
+function buildHourlyFixture() {
+  const time: string[] = []
+  const temperature_2m: number[] = []
+  const weather_code: number[] = []
+  for (let i = 0; i < 168; i++) {
+    const d = new Date('2025-03-13T00:00')
+    d.setHours(d.getHours() + i)
+    time.push(d.toISOString().slice(0, 16))
+    temperature_2m.push(50 + (i % 24))
+    weather_code.push(i % 3 === 0 ? 0 : i % 3 === 1 ? 2 : 61)
+  }
+  return { time, temperature_2m, weather_code }
+}
+
 export const OPEN_METEO_FIXTURE = {
   current: {
     temperature_2m: 72,
@@ -21,6 +35,7 @@ export const OPEN_METEO_FIXTURE = {
     sunrise: ['2025-03-13T06:30', '2025-03-14T06:29', '2025-03-15T06:28', '2025-03-16T06:27', '2025-03-17T06:26'],
     sunset: ['2025-03-13T19:45', '2025-03-14T19:46', '2025-03-15T19:47', '2025-03-16T19:48', '2025-03-17T19:49'],
   },
+  hourly: buildHourlyFixture(),
   timezone: 'America/New_York',
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
   const markerRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const lastSelectedRef = useRef<string | null>(null)
   const activeCity = selectedCity ?? DEFAULT_CITY
-  const { current, forecast, isLoading, error, source, refetch } = useWeather(activeCity)
+  const { current, forecast, hourly, isLoading, error, source, refetch } = useWeather(activeCity)
 
   // Sync URL → state on popstate (back/forward)
   useEffect(() => {
@@ -76,6 +76,7 @@ function App() {
             <Dashboard
               current={current}
               forecast={forecast}
+              hourly={hourly}
               isLoading={isLoading}
               error={error}
               source={source}

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -37,6 +37,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={null}
         forecast={[]}
+        hourly={[]}
         isLoading={true}
         error={null}
         source={null}
@@ -57,6 +58,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={null}
         forecast={[]}
+        hourly={[]}
         isLoading={false}
         error={error}
         source={null}
@@ -75,6 +77,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -94,6 +97,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -115,6 +119,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={currentWithoutUV}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="openweathermap"
@@ -135,6 +140,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -154,6 +160,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -174,6 +181,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -193,6 +201,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={[]}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -216,6 +225,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={[]}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -235,6 +245,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -252,6 +263,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"
@@ -270,6 +282,7 @@ describe('Dashboard', () => {
       <Dashboard
         current={mockCurrent}
         forecast={mockForecast}
+        hourly={[]}
         isLoading={false}
         error={null}
         source="open-meteo"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,8 +13,9 @@ import {
   Filler,
 } from 'chart.js'
 import { Line, Pie, Bar } from 'react-chartjs-2'
-import type { WeatherData, ForecastDay, WeatherError, WeatherMetric, ChartData, City } from '../types'
+import type { WeatherData, ForecastDay, HourlyForecast as HourlyForecastType, WeatherError, WeatherMetric, ChartData, City } from '../types'
 import { MetricCard } from './MetricCard'
+import { HourlyForecast } from './HourlyForecast'
 import { CityPicker } from './CityPicker'
 import { UnitToggle } from './UnitToggle'
 import { PanelSkeleton } from './PanelSkeleton'
@@ -38,6 +39,7 @@ ChartJS.register(
 interface DashboardProps {
   current: WeatherData | null
   forecast: ForecastDay[]
+  hourly: HourlyForecastType[]
   isLoading: boolean
   error: WeatherError | null
   source: 'open-meteo' | 'openweathermap' | null
@@ -46,7 +48,7 @@ interface DashboardProps {
   onCityChange: (city: City) => void
 }
 
-export function Dashboard({ current, forecast, isLoading, error, source, onRetry, city, onCityChange }: DashboardProps) {
+export function Dashboard({ current, forecast, hourly, isLoading, error, source, onRetry, city, onCityChange }: DashboardProps) {
   const [units, setUnits] = useState<UnitSystem>(getStoredUnits)
 
   const handleUnitToggle = (newUnits: UnitSystem) => {
@@ -278,6 +280,8 @@ export function Dashboard({ current, forecast, isLoading, error, source, onRetry
           <MetricCard key={metric.id} metric={metric} />
         ))}
       </section>
+
+      <HourlyForecast hours={hourly} units={units} />
 
       <section className="charts-section" aria-label="Forecast Charts">
         <div className="chart-container large">

--- a/src/components/HourlyForecast.css
+++ b/src/components/HourlyForecast.css
@@ -8,6 +8,13 @@
   margin: 0 0 12px;
 }
 
+.hourly-limited {
+  font-size: 12px;
+  color: var(--text);
+  opacity: 0.7;
+  margin: 0 0 8px;
+}
+
 .hourly-scroll {
   display: flex;
   gap: 12px;

--- a/src/components/HourlyForecast.css
+++ b/src/components/HourlyForecast.css
@@ -1,0 +1,55 @@
+.hourly-forecast {
+  margin-bottom: 24px;
+}
+
+.hourly-forecast h2 {
+  font-size: 16px;
+  font-weight: 500;
+  margin: 0 0 12px;
+}
+
+.hourly-scroll {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+
+.hourly-item {
+  flex: 0 0 auto;
+  min-width: 72px;
+  background: var(--card-bg, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 8px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hourly-time {
+  font-size: 12px;
+  color: var(--text);
+}
+
+.hourly-temp {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-h);
+}
+
+.hourly-conditions {
+  font-size: 11px;
+  color: var(--text);
+}
+
+@media (min-width: 769px) {
+  .hourly-scroll {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+    overflow-x: visible;
+  }
+}

--- a/src/components/HourlyForecast.test.tsx
+++ b/src/components/HourlyForecast.test.tsx
@@ -35,4 +35,21 @@ describe('HourlyForecast', () => {
     // 72°F = 22°C
     expect(screen.getByLabelText(/3 PM: 22°C, Clear/)).toBeInTheDocument()
   })
+
+  it('shows limited data note when fewer than 24 hours', () => {
+    render(<HourlyForecast hours={mockHours} units="imperial" />)
+    expect(screen.getByText(/Limited hourly data available/)).toBeInTheDocument()
+    expect(screen.getByText(/3 of 24 hours/)).toBeInTheDocument()
+  })
+
+  it('does not show limited data note when 24 hours present', () => {
+    const fullHours: HourlyForecastType[] = Array.from({ length: 24 }, (_, i) => ({
+      time: `${(i % 12) || 12} ${i < 12 ? 'AM' : 'PM'}`,
+      temperature: 60 + i,
+      conditions: 'Clear',
+      conditionIcon: '01d',
+    }))
+    render(<HourlyForecast hours={fullHours} units="imperial" />)
+    expect(screen.queryByText(/Limited hourly data available/)).not.toBeInTheDocument()
+  })
 })

--- a/src/components/HourlyForecast.test.tsx
+++ b/src/components/HourlyForecast.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HourlyForecast } from './HourlyForecast'
+import type { HourlyForecast as HourlyForecastType } from '../types'
+
+const mockHours: HourlyForecastType[] = [
+  { time: '3 PM', temperature: 72, conditions: 'Clear', conditionIcon: '01d' },
+  { time: '4 PM', temperature: 74, conditions: 'Clouds', conditionIcon: '03d' },
+  { time: '5 PM', temperature: 71, conditions: 'Rain', conditionIcon: '10d' },
+]
+
+describe('HourlyForecast', () => {
+  it('renders correct number of hourly items', () => {
+    render(<HourlyForecast hours={mockHours} units="imperial" />)
+    expect(screen.getAllByText(/PM/).length).toBe(3)
+  })
+
+  it('renders nothing when hours is empty', () => {
+    const { container } = render(<HourlyForecast hours={[]} units="imperial" />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('each item has accessible aria-label', () => {
+    render(<HourlyForecast hours={mockHours} units="imperial" />)
+    expect(screen.getByLabelText(/3 PM: 72°F, Clear/)).toBeInTheDocument()
+  })
+
+  it('renders section with aria-label', () => {
+    render(<HourlyForecast hours={mockHours} units="imperial" />)
+    expect(screen.getByLabelText('Hourly Forecast')).toBeInTheDocument()
+  })
+
+  it('converts temperatures for metric units', () => {
+    render(<HourlyForecast hours={mockHours} units="metric" />)
+    // 72°F = 22°C
+    expect(screen.getByLabelText(/3 PM: 22°C, Clear/)).toBeInTheDocument()
+  })
+})

--- a/src/components/HourlyForecast.tsx
+++ b/src/components/HourlyForecast.tsx
@@ -10,9 +10,14 @@ interface HourlyForecastProps {
 export function HourlyForecast({ hours, units }: HourlyForecastProps) {
   if (hours.length === 0) return null
 
+  const isLimited = hours.length > 0 && hours.length < 24
+
   return (
     <section className="hourly-forecast" aria-label="Hourly Forecast">
       <h2>Next 24 Hours</h2>
+      {isLimited && (
+        <p className="hourly-limited">Limited hourly data available ({hours.length} of 24 hours)</p>
+      )}
       <div className="hourly-scroll">
         {hours.map((hour) => (
           <div

--- a/src/components/HourlyForecast.tsx
+++ b/src/components/HourlyForecast.tsx
@@ -1,0 +1,31 @@
+import type { HourlyForecast as HourlyForecastType } from '../types'
+import { convertTemp, tempUnit, type UnitSystem } from '../utils/units'
+import './HourlyForecast.css'
+
+interface HourlyForecastProps {
+  hours: HourlyForecastType[]
+  units: UnitSystem
+}
+
+export function HourlyForecast({ hours, units }: HourlyForecastProps) {
+  if (hours.length === 0) return null
+
+  return (
+    <section className="hourly-forecast" aria-label="Hourly Forecast">
+      <h2>Next 24 Hours</h2>
+      <div className="hourly-scroll">
+        {hours.map((hour) => (
+          <div
+            key={hour.time}
+            className="hourly-item"
+            aria-label={`${hour.time}: ${convertTemp(hour.temperature, units)}${tempUnit(units)}, ${hour.conditions}`}
+          >
+            <span className="hourly-time">{hour.time}</span>
+            <span className="hourly-temp">{convertTemp(hour.temperature, units)}°</span>
+            <span className="hourly-conditions">{hour.conditions}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,12 +1,13 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { fetchWeatherData, type WeatherResult } from '../services/weatherApi'
-import type { WeatherData, ForecastDay, WeatherError, City } from '../types'
+import type { WeatherData, ForecastDay, HourlyForecast, WeatherError, City } from '../types'
 
 const REFRESH_INTERVAL = 10 * 60 * 1000
 
 interface UseWeatherResult {
   current: WeatherData | null
   forecast: ForecastDay[]
+  hourly: HourlyForecast[]
   isLoading: boolean
   error: WeatherError | null
   source: 'open-meteo' | 'openweathermap' | null
@@ -16,6 +17,7 @@ interface UseWeatherResult {
 export function useWeather(city: City): UseWeatherResult {
   const [current, setCurrent] = useState<WeatherData | null>(null)
   const [forecast, setForecast] = useState<ForecastDay[]>([])
+  const [hourly, setHourly] = useState<HourlyForecast[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<WeatherError | null>(null)
   const [source, setSource] = useState<'open-meteo' | 'openweathermap' | null>(null)
@@ -34,6 +36,7 @@ export function useWeather(city: City): UseWeatherResult {
       const data: WeatherResult = await fetchWeatherData(city, controller.signal)
       setCurrent(data.current)
       setForecast(data.forecast)
+      setHourly(data.hourly)
       setSource(data.source)
     } catch (err) {
       if (controller.signal.aborted) return
@@ -63,5 +66,5 @@ export function useWeather(city: City): UseWeatherResult {
     }
   }, [fetchData])
 
-  return { current, forecast, isLoading, error, source, refetch: fetchData }
+  return { current, forecast, hourly, isLoading, error, source, refetch: fetchData }
 }

--- a/src/services/openMeteoApi.test.ts
+++ b/src/services/openMeteoApi.test.ts
@@ -93,6 +93,15 @@ describe('fetchOpenMeteoWeather', () => {
       sunrise: ['2024-03-13T06:30', '2024-03-14T06:29', '2024-03-15T06:28', '2024-03-16T06:27', '2024-03-17T06:26', '2024-03-18T06:25'],
       sunset: ['2024-03-13T19:45', '2024-03-14T19:46', '2024-03-15T19:47', '2024-03-16T19:48', '2024-03-17T19:49', '2024-03-18T19:50'],
     },
+    hourly: {
+      time: Array.from({ length: 168 }, (_, i) => {
+        const d = new Date('2024-03-13T00:00')
+        d.setHours(d.getHours() + i)
+        return d.toISOString().slice(0, 16).replace(':00', ':00')
+      }),
+      temperature_2m: Array.from({ length: 168 }, (_, i) => 50 + (i % 24)),
+      weather_code: Array.from({ length: 168 }, (_, i) => (i % 3 === 0 ? 0 : i % 3 === 1 ? 2 : 61)),
+    },
     timezone: 'America/New_York',
   }
 
@@ -212,5 +221,44 @@ describe('fetchOpenMeteoWeather', () => {
     await fetchOpenMeteoWeather(testCity)
 
     expect(randomSpy).not.toHaveBeenCalled()
+  })
+
+  describe('hourly data parsing', () => {
+    it('includes hourly data in the result', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOpenMeteoResponse),
+      })
+
+      const result = await fetchOpenMeteoWeather(testCity)
+
+      expect(result.hourly).toBeDefined()
+      expect(Array.isArray(result.hourly)).toBe(true)
+      expect(result.hourly.length).toBeGreaterThan(0)
+    })
+
+    it('returns up to 24 hourly items', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOpenMeteoResponse),
+      })
+
+      const result = await fetchOpenMeteoWeather(testCity)
+
+      expect(result.hourly.length).toBeLessThanOrEqual(24)
+    })
+
+    it('maps conditions from weather codes', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOpenMeteoResponse),
+      })
+
+      const result = await fetchOpenMeteoWeather(testCity)
+
+      for (const hour of result.hourly) {
+        expect(['Clear', 'Clouds', 'Fog', 'Drizzle', 'Rain', 'Snow', 'Thunderstorm']).toContain(hour.conditions)
+      }
+    })
   })
 })

--- a/src/services/openMeteoApi.ts
+++ b/src/services/openMeteoApi.ts
@@ -1,4 +1,4 @@
-import type { WeatherData, ForecastDay, WeatherError, WeatherErrorType, City } from '../types'
+import type { WeatherData, ForecastDay, HourlyForecast, WeatherError, WeatherErrorType, City } from '../types'
 
 const BASE_URL = 'https://api.open-meteo.com/v1'
 
@@ -79,12 +79,27 @@ interface OpenMeteoResponse {
     sunrise: string[]
     sunset: string[]
   }
+  hourly: {
+    time: string[]
+    temperature_2m: number[]
+    weather_code: number[]
+  }
   timezone: string
 }
 
-export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): Promise<{ current: WeatherData; forecast: ForecastDay[] }> {
+function formatHour(isoDateTime: string): string {
+  const timePart = isoDateTime.split('T')[1]
+  if (!timePart) return '--'
+  const hour24 = Number.parseInt(timePart.split(':')[0], 10)
+  if (Number.isNaN(hour24)) return '--'
+  const suffix = hour24 >= 12 ? 'PM' : 'AM'
+  const hour12 = hour24 % 12 || 12
+  return `${hour12} ${suffix}`
+}
+
+export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): Promise<{ current: WeatherData; forecast: ForecastDay[]; hourly: HourlyForecast[] }> {
   try {
-    const url = `${BASE_URL}/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code,pressure_msl,apparent_temperature,wind_direction_10m,visibility,uv_index&daily=weather_code,temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,sunrise,sunset&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto`
+    const url = `${BASE_URL}/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code,pressure_msl,apparent_temperature,wind_direction_10m,visibility,uv_index&hourly=temperature_2m,weather_code&daily=weather_code,temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,sunrise,sunset&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto`
 
     const timeoutSignal = AbortSignal.timeout(10_000)
     const composedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
@@ -128,7 +143,19 @@ export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): P
       conditionIcon: '01d',
     }))
 
-    return { current, forecast }
+    const nowHour = new Date().toISOString().slice(0, 13)
+    let startIndex = data.hourly.time.findIndex((t) => t.slice(0, 13) >= nowHour)
+    if (startIndex === -1) startIndex = 0
+    const hourly: HourlyForecast[] = data.hourly.time
+      .slice(startIndex, startIndex + 24)
+      .map((t, i) => ({
+        time: formatHour(t),
+        temperature: Math.round(data.hourly.temperature_2m[startIndex + i]),
+        conditions: getConditionFromCode(data.hourly.weather_code[startIndex + i]),
+        conditionIcon: '01d',
+      }))
+
+    return { current, forecast, hourly }
   } catch (error) {
     if ((error as WeatherError).type) {
       throw error

--- a/src/services/weatherApi.test.ts
+++ b/src/services/weatherApi.test.ts
@@ -62,6 +62,9 @@ describe('fetchWeatherData', () => {
       lastUpdated: '12:00 PM',
     },
     forecast: [],
+    hourly: [
+      { time: '3 PM', temperature: 72, conditions: 'Clear', conditionIcon: '01d' },
+    ],
   }
 
   it('returns open-meteo source when primary succeeds', async () => {
@@ -92,6 +95,14 @@ describe('fetchWeatherData', () => {
     })
 
     await expect(fetchWeatherData(testCity)).rejects.toMatchObject({ type: 'network' })
+  })
+
+  it('passes hourly data through from open-meteo', async () => {
+    mockedFetchOpenMeteo.mockResolvedValue(mockWeatherResult)
+
+    const result = await fetchWeatherData(testCity)
+
+    expect(result.hourly).toEqual(mockWeatherResult.hourly)
   })
 
   it('propagates timeout error from primary', async () => {

--- a/src/services/weatherApi.ts
+++ b/src/services/weatherApi.ts
@@ -89,7 +89,20 @@ async function fetchOpenWeatherMapData(city: City, signal?: AbortSignal): Promis
     lastUpdated: new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
   }
 
-  return { current, forecast: aggregateForecasts(forecastData.list), hourly: [] }
+  const hourly: HourlyForecast[] = forecastData.list.slice(0, 8).map((item) => {
+    const date = new Date(item.dt * 1000)
+    const hour24 = date.getHours()
+    const suffix = hour24 >= 12 ? 'PM' : 'AM'
+    const hour12 = hour24 % 12 || 12
+    return {
+      time: `${hour12} ${suffix}`,
+      temperature: Math.round(item.main.temp),
+      conditions: item.weather[0].main,
+      conditionIcon: item.weather[0].icon,
+    }
+  })
+
+  return { current, forecast: aggregateForecasts(forecastData.list), hourly }
 }
 
 const CONDITION_SEVERITY: Record<string, number> = {

--- a/src/services/weatherApi.ts
+++ b/src/services/weatherApi.ts
@@ -1,4 +1,4 @@
-import type { WeatherData, ForecastDay, WeatherError, WeatherErrorType, City } from '../types'
+import type { WeatherData, ForecastDay, HourlyForecast, WeatherError, WeatherErrorType, City } from '../types'
 import { fetchOpenMeteoWeather } from './openMeteoApi'
 
 const API_KEY = import.meta.env.VITE_OPENWEATHER_API_KEY
@@ -47,7 +47,7 @@ interface ForecastResponse {
   city: { name: string; country: string; sunrise: number; sunset: number; timezone: number }
 }
 
-async function fetchOpenWeatherMapData(city: City, signal?: AbortSignal): Promise<{ current: WeatherData; forecast: ForecastDay[] }> {
+async function fetchOpenWeatherMapData(city: City, signal?: AbortSignal): Promise<{ current: WeatherData; forecast: ForecastDay[]; hourly: HourlyForecast[] }> {
   if (!API_KEY) {
     throw { type: 'invalid_key' as WeatherErrorType, message: 'OpenWeatherMap API key not configured.' }
   }
@@ -89,7 +89,7 @@ async function fetchOpenWeatherMapData(city: City, signal?: AbortSignal): Promis
     lastUpdated: new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }),
   }
 
-  return { current, forecast: aggregateForecasts(forecastData.list) }
+  return { current, forecast: aggregateForecasts(forecastData.list), hourly: [] }
 }
 
 const CONDITION_SEVERITY: Record<string, number> = {
@@ -158,6 +158,7 @@ export function aggregateForecasts(list: ForecastResponse['list']): ForecastDay[
 export interface WeatherResult {
   current: WeatherData
   forecast: ForecastDay[]
+  hourly: HourlyForecast[]
   source: 'open-meteo' | 'openweathermap'
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,13 @@ export interface ForecastDay {
   conditionIcon: string
 }
 
+export interface HourlyForecast {
+  time: string
+  temperature: number
+  conditions: string
+  conditionIcon: string
+}
+
 export interface WeatherApiResponse {
   current: WeatherData
   forecast: ForecastDay[]


### PR DESCRIPTION
## Summary
Add hourly forecast data from Open-Meteo API with a responsive horizontal scroll (mobile) / grid (desktop) display component. OWM fallback gracefully returns empty array (section hidden).

## Changes
- `src/types/index.ts`: New `HourlyForecast` interface
- `src/services/openMeteoApi.ts`: Request + parse hourly data from Open-Meteo
- `src/services/weatherApi.ts`: Pass through hourly; OWM fallback returns `[]`
- `src/hooks/useWeather.ts`: Expose `hourly` state
- `src/components/HourlyForecast.tsx`: New responsive hourly component
- `src/components/Dashboard.tsx`: Render HourlyForecast between metrics and charts
- `src/App.tsx`: Wire hourly data through

## Testing
- 8 new tests (5 component + 3 API parsing)
- 145 total tests passing

## Related Issue
Closes #23