### PR TITLE
feat: announce loading, refresh, and error states to assistive tech

### DIFF
--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -283,4 +283,78 @@ describe('Dashboard', () => {
     expect(screen.getByText('Conditions Distribution Data')).toBeInTheDocument()
     expect(screen.getByText('Humidity Forecast Data')).toBeInTheDocument()
   })
+
+  it('loading state has role="status" with accessible label', () => {
+    render(
+      <Dashboard
+        current={null}
+        forecast={[]}
+        isLoading={true}
+        error={null}
+        source={null}
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    const statusEl = screen.getByRole('status')
+    expect(statusEl).toHaveAttribute('aria-label', 'Loading weather data')
+  })
+
+  it('error state has role="alert"', () => {
+    const error = { type: 'network' as const, message: 'Connection failed' }
+    render(
+      <Dashboard
+        current={null}
+        forecast={[]}
+        isLoading={false}
+        error={error}
+        source={null}
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Connection failed')
+  })
+
+  it('announces weather data updated on refresh, not initial load', () => {
+    const { rerender } = render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        isLoading={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    // Initial load — announcement region should be empty
+    const dashboard = document.querySelector('.dashboard')!
+    const liveRegion = dashboard.querySelector('[aria-live="polite"]')!
+    expect(liveRegion.textContent).toBe('')
+
+    // Simulate data refresh
+    const updatedCurrent = { ...mockCurrent, temperature: 75, lastUpdated: '12:05 PM' }
+    rerender(
+      <Dashboard
+        current={updatedCurrent}
+        forecast={mockForecast}
+        isLoading={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(liveRegion.textContent).toBe('Weather data updated')
+  })
 })

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -48,6 +48,8 @@ interface DashboardProps {
 
 export function Dashboard({ current, forecast, isLoading, error, source, onRetry, city, onCityChange }: DashboardProps) {
   const [units, setUnits] = useState<UnitSystem>(getStoredUnits)
+  const hasLoadedRef = useRef(false)
+  const [announcement, setAnnouncement] = useState('')
 
   const handleUnitToggle = (newUnits: UnitSystem) => {
     setUnits(newUnits)
@@ -65,6 +67,17 @@ export function Dashboard({ current, forecast, isLoading, error, source, onRetry
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [])
+
+  useEffect(() => {
+    if (current && !isLoading) {
+      if (hasLoadedRef.current) {
+        setAnnouncement('Weather data updated')
+        const timer = setTimeout(() => setAnnouncement(''), 3000)
+        return () => clearTimeout(timer)
+      }
+      hasLoadedRef.current = true
+    }
+  }, [current, isLoading])
 
   const textColor = isDark ? '#9ca3af' : '#6b6375'
   const gridColor = isDark ? '#2e303a' : '#e5e4e7'
@@ -225,13 +238,17 @@ export function Dashboard({ current, forecast, isLoading, error, source, onRetry
   }, [forecast])
 
   if (isLoading) {
-    return <PanelSkeleton />
+    return (
+      <div role="status" aria-label="Loading weather data">
+        <PanelSkeleton />
+      </div>
+    )
   }
 
   if (error) {
     return (
       <div className="dashboard">
-        <div className="error-state">
+        <div className="error-state" role="alert">
           <h2>Unable to load weather data</h2>
           <p>{error.message}</p>
           <button onClick={onRetry} className="retry-button">
@@ -349,6 +366,10 @@ export function Dashboard({ current, forecast, isLoading, error, source, onRetry
           <span className="info-value">{current.pressure} hPa</span>
         </div>
       </section>
+
+      <div className="sr-only" aria-live="polite" role="status">
+        {announcement}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Add ARIA live regions to announce weather data state changes to screen readers. Loading gets `role=status`, errors get `role=alert`, and a polite live region announces data refreshes (not initial load).

## Changes
- `src/components/Dashboard.tsx`: Add `role=status` to loading, `role=alert` to error, polite live region for refresh announcements

## Testing
- 3 new tests (loading role, error role, refresh announcement)
- 140 total tests passing

## Related Issue
Closes #14