### PR TITLE
fix: improve panel close behavior and transition robustness

### DIFF
--- a/src/components/WeatherPanel.test.tsx
+++ b/src/components/WeatherPanel.test.tsx
@@ -163,6 +163,117 @@ describe('WeatherPanel', () => {
     })
   })
 
+  describe('transition robustness', () => {
+    it('onTransitionEnd fires after panel close animation', async () => {
+      const onClose = vi.fn()
+      const { container, rerender } = render(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Atlanta">
+          <div>content</div>
+        </WeatherPanel>
+      )
+
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      // Close the panel
+      fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
+
+      rerender(
+        <WeatherPanel isOpen={false} onClose={onClose} cityName="Atlanta">
+          <div>content</div>
+        </WeatherPanel>
+      )
+
+      // Simulate transitionend event on the panel element
+      const panel = container.querySelector('.weather-panel')!
+      fireEvent.transitionEnd(panel)
+
+      // Panel state should be clean (not expanded, not dragging)
+      expect(panel.classList.contains('expanded')).toBe(false)
+      expect(panel.classList.contains('dragging')).toBe(false)
+    })
+
+    it('handles rapid close/open without breaking state', async () => {
+      const onClose = vi.fn()
+      const { rerender } = render(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Atlanta">
+          <div>Atlanta content</div>
+        </WeatherPanel>
+      )
+
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      // Close
+      fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
+
+      rerender(
+        <WeatherPanel isOpen={false} onClose={onClose} cityName="Atlanta">
+          <div>Atlanta content</div>
+        </WeatherPanel>
+      )
+
+      // Immediately reopen with different city (before transition completes)
+      rerender(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Tokyo">
+          <div>Tokyo content</div>
+        </WeatherPanel>
+      )
+
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      // Panel should show the latest content
+      expect(screen.getByText('Tokyo')).toBeInTheDocument()
+      expect(screen.getByText('Tokyo content')).toBeInTheDocument()
+    })
+
+    it('all three close methods call the same handler', async () => {
+      const onClose = vi.fn()
+      const { container } = render(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Atlanta">
+          <button>Inside</button>
+        </WeatherPanel>
+      )
+
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      // Method 1: Close button
+      fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
+      const closeButtonCalls = onClose.mock.calls.length
+      expect(closeButtonCalls).toBeGreaterThanOrEqual(1)
+
+      onClose.mockClear()
+
+      // Method 2: Backdrop click — need fresh render since isClosingRef blocks
+      const { container: c2, unmount: u2 } = render(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Atlanta">
+          <button>Inside</button>
+        </WeatherPanel>
+      )
+      const backdrop = c2.querySelector('.weather-panel-backdrop')!
+      fireEvent.click(backdrop)
+      expect(onClose).toHaveBeenCalledTimes(1)
+      u2()
+
+      onClose.mockClear()
+
+      // Method 3: Escape key
+      render(
+        <WeatherPanel isOpen={true} onClose={onClose} cityName="Atlanta">
+          <button>Inside</button>
+        </WeatherPanel>
+      )
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('scroll lock', () => {
     it('sets body overflow to hidden when open', () => {
       renderPanel({ isOpen: true })

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -20,6 +20,7 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
   const touchStart = useRef<{ y: number; time: number } | null>(null)
   const isMobileRef = useRef(false)
   const previousFocusRef = useRef<HTMLElement | null>(null)
+  const isClosingRef = useRef(false)
 
   useEffect(() => {
     const check = () => { isMobileRef.current = window.innerWidth <= 768 }
@@ -31,6 +32,7 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
   // Focus-on-open + capture previous focus for restore
   useEffect(() => {
     if (isOpen) {
+      isClosingRef.current = false
       previousFocusRef.current = document.activeElement as HTMLElement | null
       requestAnimationFrame(() => {
         const panel = panelRef.current
@@ -57,6 +59,8 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
 
   // Focus restore on close
   const handleClose = useCallback(() => {
+    if (isClosingRef.current) return
+    isClosingRef.current = true
     const elToRestore = previousFocusRef.current
     onClose()
     requestAnimationFrame(() => {
@@ -143,6 +147,13 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
     touchStart.current = null
   }, [translateY, expanded, handleClose])
 
+  const handleTransitionEnd = useCallback((e: React.TransitionEvent) => {
+    if (e.target !== panelRef.current) return
+    if (!isOpen) {
+      isClosingRef.current = false
+    }
+  }, [isOpen])
+
   // Prevent body scroll when panel is open (all viewports)
   useEffect(() => {
     if (isOpen) {
@@ -171,6 +182,7 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
         aria-modal="true"
         aria-labelledby={headingId}
         tabIndex={-1}
+        onTransitionEnd={handleTransitionEnd}
       >
         <div
           className="weather-panel-handle"


### PR DESCRIPTION
## Summary
Tie panel cleanup to `transitionend` events instead of CSS timing assumptions. Add `isClosing` guard to prevent rapid close/open race conditions. All close methods already share the same handler.

## Changes
- `src/components/WeatherPanel.tsx`: Add `onTransitionEnd` handler, `isClosingRef` guard

## Testing
- 3 new tests (transitionend, rapid close/open, all-close-methods parity)
- 140 total tests passing

## Related Issue
Closes #15