### PR TITLE
[W-000005] Add per-city caching with stale-while-refresh behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
   const markerRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const lastSelectedRef = useRef<string | null>(null)
   const activeCity = selectedCity ?? DEFAULT_CITY
-  const { current, forecast, hourly, isLoading, error, source, refetch } = useWeather(activeCity)
+  const { current, forecast, hourly, isLoading, isRefreshing, isStale, error, source, refetch } = useWeather(activeCity)
 
   // Sync URL → state on popstate (back/forward)
   useEffect(() => {
@@ -78,6 +78,8 @@ function App() {
               forecast={forecast}
               hourly={hourly}
               isLoading={isLoading}
+              isRefreshing={isRefreshing}
+              isStale={isStale}
               error={error}
               source={source}
               onRetry={refetch}

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -77,6 +77,16 @@
   opacity: 0.7;
 }
 
+.refreshing-indicator {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.stale-indicator {
+  font-size: 12px;
+  color: #d97706;
+}
+
 .current-conditions {
   color: var(--text);
   margin: 0;

--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -39,6 +39,8 @@ describe('Dashboard', () => {
         forecast={[]}
         hourly={[]}
         isLoading={true}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source={null}
         onRetry={vi.fn()}
@@ -60,6 +62,8 @@ describe('Dashboard', () => {
         forecast={[]}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={error}
         source={null}
         onRetry={vi.fn()}
@@ -79,6 +83,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -99,6 +105,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -121,6 +129,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="openweathermap"
         onRetry={vi.fn()}
@@ -142,6 +152,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -162,6 +174,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -183,6 +197,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -203,6 +219,8 @@ describe('Dashboard', () => {
         forecast={[]}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -227,6 +245,8 @@ describe('Dashboard', () => {
         forecast={[]}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -247,6 +267,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -265,6 +287,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -284,6 +308,8 @@ describe('Dashboard', () => {
         forecast={mockForecast}
         hourly={[]}
         isLoading={false}
+        isRefreshing={false}
+        isStale={false}
         error={null}
         source="open-meteo"
         onRetry={vi.fn()}
@@ -295,5 +321,68 @@ describe('Dashboard', () => {
     expect(screen.getByText('Temperature Trend Data')).toBeInTheDocument()
     expect(screen.getByText('Conditions Distribution Data')).toBeInTheDocument()
     expect(screen.getByText('Humidity Forecast Data')).toBeInTheDocument()
+  })
+
+  it('shows refreshing indicator when isRefreshing is true', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={true}
+        isStale={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Refreshing…/)).toBeInTheDocument()
+    expect(screen.queryByText(/Data may be outdated/)).not.toBeInTheDocument()
+  })
+
+  it('shows stale indicator when isStale is true', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={false}
+        isStale={true}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/Data may be outdated/)).toBeInTheDocument()
+    expect(screen.queryByText(/Refreshing…/)).not.toBeInTheDocument()
+  })
+
+  it('hides refresh and stale indicators when both are false', () => {
+    render(
+      <Dashboard
+        current={mockCurrent}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={false}
+        isStale={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/Refreshing…/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Data may be outdated/)).not.toBeInTheDocument()
   })
 })

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -41,6 +41,8 @@ interface DashboardProps {
   forecast: ForecastDay[]
   hourly: HourlyForecastType[]
   isLoading: boolean
+  isRefreshing: boolean
+  isStale: boolean
   error: WeatherError | null
   source: 'open-meteo' | 'openweathermap' | null
   onRetry: () => void
@@ -48,7 +50,7 @@ interface DashboardProps {
   onCityChange: (city: City) => void
 }
 
-export function Dashboard({ current, forecast, hourly, isLoading, error, source, onRetry, city, onCityChange }: DashboardProps) {
+export function Dashboard({ current, forecast, hourly, isLoading, isRefreshing, isStale, error, source, onRetry, city, onCityChange }: DashboardProps) {
   const [units, setUnits] = useState<UnitSystem>(getStoredUnits)
 
   const handleUnitToggle = (newUnits: UnitSystem) => {
@@ -268,6 +270,8 @@ export function Dashboard({ current, forecast, hourly, isLoading, error, source,
         </div>
         <p className="dashboard-subtitle">
           {current.location} • Updated {current.lastUpdated}
+          {isRefreshing && <span className="refreshing-indicator"> • Refreshing…</span>}
+          {isStale && <span className="stale-indicator"> • Data may be outdated</span>}
           {source && <span className="data-source"> • {source === 'open-meteo' ? 'Open-Meteo' : 'OpenWeatherMap'}</span>}
         </p>
         <p className="current-conditions">

--- a/src/hooks/useWeather.test.ts
+++ b/src/hooks/useWeather.test.ts
@@ -4,8 +4,13 @@ import { useWeather } from './useWeather'
 import type { City, WeatherError } from '../types'
 
 vi.mock('../services/weatherApi')
+vi.mock('../services/weatherCache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/weatherCache')>()
+  return { ...actual }
+})
 
 import { fetchWeatherData } from '../services/weatherApi'
+import { clearCache } from '../services/weatherCache'
 
 const mockedFetch = vi.mocked(fetchWeatherData)
 
@@ -70,6 +75,8 @@ function makeResult(cityName: string, country: string, source: 'open-meteo' | 'o
 
 afterEach(() => {
   vi.restoreAllMocks()
+  clearCache('atlanta')
+  clearCache('tokyo')
 })
 
 describe('useWeather', () => {
@@ -262,6 +269,138 @@ describe('useWeather', () => {
       })
 
       expect(mockedFetch.mock.calls.length).toBe(callsAfterUnmount)
+    })
+  })
+
+  describe('caching', () => {
+    it('shows cached data instantly without loading on revisit', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result, unmount } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      unmount()
+
+      mockedFetch.mockClear()
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result: result2 } = renderHook(() => useWeather(atlanta))
+
+      expect(result2.current.isLoading).toBe(false)
+      expect(result2.current.current?.location).toBe('Atlanta, US')
+    })
+
+    it('background refresh updates data when cache is stale', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result, unmount } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      unmount()
+
+      // Make cache stale
+      const { getCache } = await import('../services/weatherCache')
+      const entry = getCache('atlanta')!
+      entry.timestamp = Date.now() - 11 * 60 * 1000
+
+      mockedFetch.mockResolvedValue(makeResult('Atlanta Updated', 'US'))
+
+      const { result: result2 } = renderHook(() => useWeather(atlanta))
+
+      expect(result2.current.isLoading).toBe(false)
+      expect(result2.current.current?.location).toBe('Atlanta, US')
+      expect(result2.current.isRefreshing).toBe(true)
+
+      await waitFor(() => {
+        expect(result2.current.isRefreshing).toBe(false)
+      })
+
+      expect(result2.current.current?.location).toBe('Atlanta Updated, US')
+    })
+
+    it('failed background refresh preserves cache and sets isStale', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result, unmount } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      unmount()
+
+      // Make cache stale
+      const { getCache } = await import('../services/weatherCache')
+      const entry = getCache('atlanta')!
+      entry.timestamp = Date.now() - 11 * 60 * 1000
+
+      const weatherError: WeatherError = { type: 'network', message: 'Network error.' }
+      mockedFetch.mockRejectedValue(weatherError)
+
+      const { result: result2 } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result2.current.isRefreshing).toBe(false)
+      })
+
+      expect(result2.current.current?.location).toBe('Atlanta, US')
+      expect(result2.current.isStale).toBe(true)
+      expect(result2.current.error).toBeNull()
+    })
+
+    it('manual refetch bypasses cache', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      mockedFetch.mockResolvedValue(makeResult('Atlanta Fresh', 'US'))
+
+      await act(async () => {
+        await result.current.refetch()
+      })
+
+      expect(result.current.current?.location).toBe('Atlanta Fresh, US')
+    })
+
+    it('switching cities reuses cache', async () => {
+      mockedFetch.mockImplementation(async (city) => {
+        if (city.id === 'atlanta') return makeResult('Atlanta', 'US')
+        return makeResult('Tokyo', 'JP')
+      })
+
+      const { result, rerender } = renderHook(
+        ({ city }) => useWeather(city),
+        { initialProps: { city: atlanta } },
+      )
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      rerender({ city: tokyo })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.current?.location).toBe('Tokyo, JP')
+
+      mockedFetch.mockClear()
+
+      rerender({ city: atlanta })
+
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.current?.location).toBe('Atlanta, US')
     })
   })
 })

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { fetchWeatherData, type WeatherResult } from '../services/weatherApi'
+import { getCache, setCache, clearCache, isFresh } from '../services/weatherCache'
 import type { WeatherData, ForecastDay, HourlyForecast, WeatherError, City } from '../types'
 
 const REFRESH_INTERVAL = 10 * 60 * 1000
@@ -9,6 +10,8 @@ interface UseWeatherResult {
   forecast: ForecastDay[]
   hourly: HourlyForecast[]
   isLoading: boolean
+  isRefreshing: boolean
+  isStale: boolean
   error: WeatherError | null
   source: 'open-meteo' | 'openweathermap' | null
   refetch: () => Promise<void>
@@ -19,35 +22,70 @@ export function useWeather(city: City): UseWeatherResult {
   const [forecast, setForecast] = useState<ForecastDay[]>([])
   const [hourly, setHourly] = useState<HourlyForecast[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isStale, setIsStale] = useState(false)
   const [error, setError] = useState<WeatherError | null>(null)
   const [source, setSource] = useState<'open-meteo' | 'openweathermap' | null>(null)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const fetchData = useCallback(async () => {
+  const hydrate = useCallback((data: WeatherResult) => {
+    setCurrent(data.current)
+    setForecast(data.forecast)
+    setHourly(data.hourly)
+    setSource(data.source)
+  }, [])
+
+  const fetchData = useCallback(async (bypassCache = false) => {
     abortControllerRef.current?.abort()
     const controller = new AbortController()
     abortControllerRef.current = controller
 
-    setIsLoading(true)
-    setError(null)
+    if (bypassCache) {
+      clearCache(city.id)
+    }
+
+    const cached = getCache(city.id)
+    const hasCachedData = cached !== undefined
+
+    if (hasCachedData && !bypassCache) {
+      hydrate(cached.data)
+      setError(null)
+      setIsLoading(false)
+
+      if (isFresh(cached)) {
+        return
+      }
+
+      setIsRefreshing(true)
+    } else {
+      setIsLoading(true)
+      setError(null)
+    }
 
     try {
       const data: WeatherResult = await fetchWeatherData(city, controller.signal)
-      setCurrent(data.current)
-      setForecast(data.forecast)
-      setHourly(data.hourly)
-      setSource(data.source)
+      if (controller.signal.aborted) return
+      setCache(city.id, data)
+      hydrate(data)
+      setIsStale(false)
     } catch (err) {
       if (controller.signal.aborted) return
-      setError(err as WeatherError)
-      setSource(null)
+      if (hasCachedData && !bypassCache) {
+        setIsStale(true)
+      } else {
+        setError(err as WeatherError)
+        setSource(null)
+      }
     } finally {
       if (!controller.signal.aborted) {
         setIsLoading(false)
+        setIsRefreshing(false)
       }
     }
-  }, [city])
+  }, [city, hydrate])
+
+  const refetch = useCallback(() => fetchData(true), [fetchData])
 
   useEffect(() => {
     fetchData()
@@ -56,7 +94,7 @@ export function useWeather(city: City): UseWeatherResult {
       clearInterval(intervalRef.current)
     }
 
-    intervalRef.current = setInterval(fetchData, REFRESH_INTERVAL)
+    intervalRef.current = setInterval(() => fetchData(), REFRESH_INTERVAL)
 
     return () => {
       if (intervalRef.current) {
@@ -66,5 +104,5 @@ export function useWeather(city: City): UseWeatherResult {
     }
   }, [fetchData])
 
-  return { current, forecast, hourly, isLoading, error, source, refetch: fetchData }
+  return { current, forecast, hourly, isLoading, isRefreshing, isStale, error, source, refetch }
 }

--- a/src/services/weatherCache.test.ts
+++ b/src/services/weatherCache.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getCache, setCache, clearCache, isFresh } from './weatherCache'
+import type { WeatherResult } from './weatherApi'
+
+const makeData = (location: string): WeatherResult => ({
+  current: {
+    location,
+    temperature: 73,
+    humidity: 65,
+    pressure: 1015,
+    windSpeed: 12,
+    conditions: 'Clear',
+    conditionIcon: '01d',
+    sunrise: '6:30 AM',
+    sunset: '7:45 PM',
+    lastUpdated: '12:00 PM',
+  },
+  forecast: [],
+  hourly: [],
+  source: 'open-meteo',
+})
+
+afterEach(() => {
+  clearCache('atlanta')
+  clearCache('tokyo')
+  vi.restoreAllMocks()
+})
+
+describe('weatherCache', () => {
+  it('returns undefined for cache miss', () => {
+    expect(getCache('nonexistent')).toBeUndefined()
+  })
+
+  it('stores and retrieves cached data', () => {
+    const data = makeData('Atlanta, US')
+    setCache('atlanta', data)
+
+    const entry = getCache('atlanta')
+    expect(entry).toBeDefined()
+    expect(entry!.data.current.location).toBe('Atlanta, US')
+  })
+
+  it('clears cache for a specific city', () => {
+    setCache('atlanta', makeData('Atlanta, US'))
+    setCache('tokyo', makeData('Tokyo, JP'))
+
+    clearCache('atlanta')
+
+    expect(getCache('atlanta')).toBeUndefined()
+    expect(getCache('tokyo')).toBeDefined()
+  })
+
+  it('isFresh returns true within maxAge', () => {
+    setCache('atlanta', makeData('Atlanta, US'))
+    const entry = getCache('atlanta')!
+
+    expect(isFresh(entry)).toBe(true)
+  })
+
+  it('isFresh returns false after maxAge', () => {
+    setCache('atlanta', makeData('Atlanta, US'))
+    const entry = getCache('atlanta')!
+
+    vi.spyOn(Date, 'now').mockReturnValue(entry.timestamp + 10 * 60 * 1000 + 1)
+
+    expect(isFresh(entry)).toBe(false)
+  })
+
+  it('isFresh respects custom maxAge', () => {
+    setCache('atlanta', makeData('Atlanta, US'))
+    const entry = getCache('atlanta')!
+
+    vi.spyOn(Date, 'now').mockReturnValue(entry.timestamp + 5000)
+
+    expect(isFresh(entry, 10000)).toBe(true)
+    expect(isFresh(entry, 3000)).toBe(false)
+  })
+})

--- a/src/services/weatherCache.ts
+++ b/src/services/weatherCache.ts
@@ -1,0 +1,26 @@
+import type { WeatherResult } from './weatherApi'
+
+const REFRESH_INTERVAL = 10 * 60 * 1000
+
+interface CacheEntry {
+  data: WeatherResult
+  timestamp: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+export function getCache(cityId: string): CacheEntry | undefined {
+  return cache.get(cityId)
+}
+
+export function setCache(cityId: string, data: WeatherResult): void {
+  cache.set(cityId, { data, timestamp: Date.now() })
+}
+
+export function clearCache(cityId: string): void {
+  cache.delete(cityId)
+}
+
+export function isFresh(entry: CacheEntry, maxAge: number = REFRESH_INTERVAL): boolean {
+  return Date.now() - entry.timestamp < maxAge
+}


### PR DESCRIPTION
## Summary

Adds in-memory per-city caching with stale-while-refresh behavior so previously viewed cities load instantly.

### Changes
- **weatherCache.ts** — In-memory Map keyed by city.id with getCache/setCache/clearCache/isFresh (10-min freshness)
- **useWeather.ts** — Fresh cache: instant hydrate, skip fetch. Stale cache: hydrate immediately + background refresh. No cache: loading spinner as before.
- **isRefreshing / isStale** — New hook states wired through App → Dashboard
- **Dashboard header** — Subtle "Refreshing…" and "Data may be outdated" indicators
- **Manual retry** — refetch clears cache before fetching

### Tests
- 6 cache unit tests (get/set/clear/freshness)
- 5 hook caching tests (instant revisit, background refresh, failed refresh + isStale, bypass cache, city switching)
- 3 Dashboard indicator tests

All 162 tests pass, TypeScript clean, build succeeds.

Closes #5