### PR TITLE
feat: [W-000017] Rework weather panel for mobile-first layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>performance-teardown-demo</title>
   </head>
   <body>

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -296,7 +296,33 @@
     font-size: 24px;
   }
 
+  .header-controls {
+    flex-wrap: wrap;
+  }
+
+  .chart-container {
+    padding: 16px;
+  }
+
+  .chart-wrapper {
+    height: 200px;
+  }
+
   .additional-info {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 375px) {
+  .dashboard {
+    padding: 12px;
+  }
+
+  .dashboard-header {
+    margin-bottom: 20px;
+  }
+
+  .chart-wrapper {
+    height: 180px;
   }
 }

--- a/src/components/WeatherPanel.css
+++ b/src/components/WeatherPanel.css
@@ -109,23 +109,42 @@
   }
 }
 
-/* Mobile: bottom sheet */
+/* Mobile: full-height sheet */
 @media (max-width: 768px) {
   .weather-panel {
     left: 0;
     right: 0;
+    top: 0;
     bottom: 0;
-    height: 50vh;
-    border-radius: 16px 16px 0 0;
+    border-radius: 0;
     transform: translateY(100%);
+    padding-top: env(safe-area-inset-top, 0px);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
   }
 
   .weather-panel.open {
     transform: translateY(0);
   }
 
-  .weather-panel.expanded {
-    height: 100vh;
+  .weather-panel-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg);
+    padding-left: max(20px, env(safe-area-inset-left, 0px));
+    padding-right: max(20px, env(safe-area-inset-right, 0px));
+  }
+
+  .weather-panel-body {
+    padding-left: env(safe-area-inset-left, 0px);
+    padding-right: env(safe-area-inset-right, 0px);
+  }
+
+  .weather-panel-close {
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+    height: 44px;
   }
 }
 

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -128,14 +128,7 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
     const threshold = panelHeight * DISMISS_THRESHOLD
 
     if (translateY > threshold) {
-      // Dismiss
       handleClose()
-    } else if (translateY < -50 && !expanded) {
-      // Swipe up → expand
-      setExpanded(true)
-    } else if (translateY > 50 && expanded) {
-      // Swipe down from expanded → collapse to half
-      setExpanded(false)
     }
 
     setTranslateY(0)


### PR DESCRIPTION
## Summary
Reworks the weather panel from a 50vh half-sheet to a full-height mobile panel with sticky header, safe area insets, and improved touch targets.

## Related Issue
Closes #17

## Changes
- `index.html`: Add `viewport-fit=cover` for iOS safe areas
- `src/components/WeatherPanel.css`: Full-height panel, sticky header, safe-area padding, 44px close button
- `src/components/WeatherPanel.tsx`: Simplified swipe handler (dismiss only)
- `src/components/Dashboard.css`: Reduced chart heights on mobile, wrapping header controls

## Acceptance Criteria
- ✅ Panel spans full viewport on mobile (≤768px)
- ✅ Charts stack vertically without horizontal scroll
- ✅ Safe area insets respected (env() padding + viewport-fit=cover)
- ✅ Header stays sticky and reachable while scrolling

## Testing
- CSS-only changes + minor touch handler simplification
- All 167 tests passing
- Build succeeds