### PR TITLE
feat: pause auto-refresh when tab is hidden (#7)

### DIFF
--- a/src/hooks/useWeather.test.ts
+++ b/src/hooks/useWeather.test.ts
@@ -252,6 +252,74 @@ describe('useWeather', () => {
       expect(mockedFetch.mock.calls.length).toBeGreaterThan(callsAfterMount)
     })
 
+    it('pauses interval when tab becomes hidden', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      const callsAfterMount = mockedFetch.mock.calls.length
+
+      // Simulate tab becoming hidden
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true })
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      await act(async () => {
+        vi.advanceTimersByTime(REFRESH_INTERVAL * 2)
+      })
+
+      // No new fetches should have happened
+      expect(mockedFetch.mock.calls.length).toBe(callsAfterMount)
+
+      // Restore
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
+    it('resumes fetching when tab becomes visible again', async () => {
+      mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
+
+      const { result } = renderHook(() => useWeather(atlanta))
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      // Hide the tab
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true })
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      // Make cache stale so fetchData actually calls fetchWeatherData on resume
+      const { getCache: getCacheEntry } = await import('../services/weatherCache')
+      const entry = getCacheEntry('atlanta')!
+      entry.timestamp = Date.now() - 11 * 60 * 1000
+
+      const callsWhileHidden = mockedFetch.mock.calls.length
+
+      // Show again — should trigger immediate network fetch (stale cache)
+      mockedFetch.mockResolvedValue(makeResult('Atlanta Refreshed', 'US'))
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+      document.dispatchEvent(new Event('visibilitychange'))
+
+      await waitFor(() => {
+        expect(mockedFetch.mock.calls.length).toBeGreaterThan(callsWhileHidden)
+      })
+
+      // Interval should also have restarted
+      const callsAfterResume = mockedFetch.mock.calls.length
+
+      await act(async () => {
+        vi.advanceTimersByTime(REFRESH_INTERVAL)
+      })
+
+      expect(mockedFetch.mock.calls.length).toBeGreaterThan(callsAfterResume)
+
+      // Restore
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true })
+    })
+
     it('clears interval on unmount and prevents further fetches', async () => {
       mockedFetch.mockResolvedValue(makeResult('Atlanta', 'US'))
 

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -90,16 +90,34 @@ export function useWeather(city: City): UseWeatherResult {
   useEffect(() => {
     fetchData()
 
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current)
+    const startInterval = () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      intervalRef.current = setInterval(() => fetchData(), REFRESH_INTERVAL)
     }
 
-    intervalRef.current = setInterval(() => fetchData(), REFRESH_INTERVAL)
-
-    return () => {
+    const stopInterval = () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current)
+        intervalRef.current = null
       }
+    }
+
+    startInterval()
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopInterval()
+      } else {
+        fetchData()
+        startInterval()
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      stopInterval()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
       abortControllerRef.current?.abort()
     }
   }, [fetchData])


### PR DESCRIPTION
## Summary
Closes #7

Pauses the 10-minute auto-refresh interval in `useWeather` when the browser tab becomes hidden (`document.hidden`), and resumes with an immediate fetch when the tab becomes visible again. Conserves battery and network on background tabs.

## Changes
- **`src/hooks/useWeather.ts`**: Added `visibilitychange` listener that stops/starts the refresh interval
- **`src/hooks/useWeather.test.ts`**: 2 new tests — pauses when hidden, resumes when visible

## Testing
- 169 tests passing
- Typecheck clean