### PR TITLE
feat: add CI quality gates for a11y and bundle size (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
       - run: npx tsc --noEmit -p tsconfig.app.json
       - run: npm run test:run
       - run: npm run build
+
+      - name: Report bundle size
+        run: |
+          echo "## Bundle size" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          du -sh dist/ >> "$GITHUB_STEP_SUMMARY"
+          du -sh dist/assets/*.js >> "$GITHUB_STEP_SUMMARY"
+          du -sh dist/assets/*.css >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
       - run: npx playwright install --with-deps chromium
       - run: npx playwright test --project=chromium
         env:

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { mockWeatherApi } from './fixtures/weather'
+
+test.beforeEach(async ({ page }) => {
+  await mockWeatherApi(page)
+})
+
+test.describe('Accessibility – axe-core audit', () => {
+  test('home page has no a11y violations', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('.map-container')).toBeVisible({ timeout: 10000 })
+
+    const results = await new AxeBuilder({ page }).analyze()
+
+    expect(results.violations).toEqual([])
+  })
+
+  test('weather panel open state has no a11y violations', async ({ page }) => {
+    await page.goto('/?city=atlanta')
+    await expect(page.locator('.weather-panel.open')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('.dashboard-header')).toBeVisible({ timeout: 15000 })
+
+    const results = await new AxeBuilder({ page }).analyze()
+
+    expect(results.violations).toEqual([])
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.9.1",
@@ -108,6 +109,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1991,6 +2005,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary
Closes #22

Adds lightweight automated quality checks to the CI pipeline.

## Changes
- **`e2e/a11y.spec.ts`**: axe-core accessibility scans for home page and panel-open state
- **`.github/workflows/ci.yml`**: Bundle size reporting step (logs to job summary)
- **`package.json`**: Added `@axe-core/playwright` dev dependency

## Testing
- 169 unit tests passing
- Typecheck clean