### PR TITLE
feat: tie panel close to transition lifecycle (#15)

### DIFF
--- a/src/components/WeatherPanel.test.tsx
+++ b/src/components/WeatherPanel.test.tsx
@@ -80,6 +80,7 @@ describe('WeatherPanel', () => {
       })
 
       // Close via close button
+      const panel = screen.getByRole('dialog')
       fireEvent.click(screen.getByRole('button', { name: 'Close panel' }))
       expect(onClose).toHaveBeenCalled()
 
@@ -89,9 +90,8 @@ describe('WeatherPanel', () => {
         </WeatherPanel>
       )
 
-      await act(async () => {
-        await new Promise((r) => requestAnimationFrame(r))
-      })
+      // Simulate the CSS transition completing on the panel element
+      fireEvent.transitionEnd(panel, { target: panel })
 
       expect(document.activeElement).toBe(triggerBtn)
 

--- a/src/components/WeatherPanel.tsx
+++ b/src/components/WeatherPanel.tsx
@@ -55,13 +55,27 @@ export function WeatherPanel({ isOpen, onClose, cityName, children }: WeatherPan
     }
   }, [isOpen])
 
-  // Focus restore on close
+  // Focus restore on close — deferred until the slide-out transition ends
   const handleClose = useCallback(() => {
     const elToRestore = previousFocusRef.current
+    const panel = panelRef.current
     onClose()
-    requestAnimationFrame(() => {
+
+    if (panel) {
+      const restore = () => {
+        clearTimeout(fallback)
+        panel.removeEventListener('transitionend', onEnd)
+        elToRestore?.focus()
+      }
+      const onEnd = (e: TransitionEvent) => {
+        if (e.target === panel) restore()
+      }
+      panel.addEventListener('transitionend', onEnd)
+      // Fallback in case transitionend never fires (e.g. prefers-reduced-motion)
+      const fallback = setTimeout(restore, 400)
+    } else {
       elToRestore?.focus()
-    })
+    }
   }, [onClose])
 
   // Escape key + focus trap


### PR DESCRIPTION
## Summary
Closes #15

Replaces the `requestAnimationFrame`-based focus restore with a `transitionend` listener so focus returns to the trigger element only after the CSS slide-out animation completes.

## Changes
- **`src/components/WeatherPanel.tsx`**: Focus restore now waits for `transitionend` with 400ms fallback
- **`src/components/WeatherPanel.test.tsx`**: Updated test to fire `transitionEnd` event

## Testing
- 169 unit tests passing
- Typecheck clean