### PR TITLE
feat(a11y): announce loading, refresh, error, and stale states (#14)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { WeatherPanel } from './components/WeatherPanel'
 import { InvalidCityView } from './components/InvalidCityView'
 import { PanelSkeleton } from './components/PanelSkeleton'
 import { useWeather } from './hooks/useWeather'
+import { useStatusAnnouncement } from './hooks/useStatusAnnouncement'
 import { CITIES, DEFAULT_CITY, type City } from './types'
 import { getCityById } from './utils/cityUrl'
 import './App.css'
@@ -37,11 +38,20 @@ function App() {
     setInvalidCityId(invalidId)
   }, [cityId])
 
-  const announcement = useMemo(() => selectedCity ? `${selectedCity.name} selected, weather panel opened` : '', [selectedCity])
   const markerRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const lastSelectedRef = useRef<string | null>(null)
   const activeCity = selectedCity ?? DEFAULT_CITY
   const { current, forecast, hourly, isLoading, isRefreshing, isStale, error, source, refetch } = useWeather(activeCity)
+
+  // Announce loading / error / refresh / stale status changes for assistive tech
+  const [announcement, setAnnouncement] = useStatusAnnouncement({ isLoading, isRefreshing, isStale, error })
+
+  // Announce city selection (overrides current status announcement)
+  useEffect(() => {
+    if (selectedCity) {
+      setAnnouncement(`${selectedCity.name} selected, weather panel opened`)
+    }
+  }, [selectedCity, setAnnouncement])
 
   const selectCity = useCallback((city: City | null) => {
     setSelectedCity(city)

--- a/src/hooks/useStatusAnnouncement.test.ts
+++ b/src/hooks/useStatusAnnouncement.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useStatusAnnouncement } from './useStatusAnnouncement'
+import type { WeatherError } from '../types'
+
+const baseProps = {
+  isLoading: false,
+  isRefreshing: false,
+  isStale: false,
+  error: null as WeatherError | null,
+}
+
+describe('useStatusAnnouncement', () => {
+  it('starts with empty announcement', () => {
+    const { result } = renderHook(() => useStatusAnnouncement(baseProps))
+    expect(result.current[0]).toBe('')
+  })
+
+  it('announces loading when isLoading transitions to true', () => {
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: baseProps,
+    })
+    rerender({ ...baseProps, isLoading: true })
+    expect(result.current[0]).toBe('Loading weather data')
+  })
+
+  it('announces error with recovery action when error appears', () => {
+    const error: WeatherError = { type: 'network', message: 'Network unavailable' }
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: baseProps,
+    })
+    rerender({ ...baseProps, error })
+    expect(result.current[0]).toBe('Error: Network unavailable. Activate Try Again to retry.')
+  })
+
+  it('does not re-announce the same error on every render', () => {
+    const error: WeatherError = { type: 'network', message: 'Network unavailable' }
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: { ...baseProps, error },
+    })
+    expect(result.current[0]).toBe('Error: Network unavailable. Activate Try Again to retry.')
+
+    // Manually clear announcement; same error reference should not trigger again
+    act(() => result.current[1](''))
+    rerender({ ...baseProps, error })
+    expect(result.current[0]).toBe('')
+  })
+
+  it('announces "Weather data updated" once after refresh completes', () => {
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: { ...baseProps, isRefreshing: true },
+    })
+    rerender({ ...baseProps, isRefreshing: false })
+    expect(result.current[0]).toBe('Weather data updated')
+  })
+
+  it('does not announce refresh complete when an error is present', () => {
+    const error: WeatherError = { type: 'network', message: 'Failed' }
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: { ...baseProps, isRefreshing: true },
+    })
+    rerender({ ...baseProps, isRefreshing: false, error })
+    expect(result.current[0]).toBe('Error: Failed. Activate Try Again to retry.')
+  })
+
+  it('announces stale data once when transitioning into stale state', () => {
+    const { result, rerender } = renderHook((props) => useStatusAnnouncement(props), {
+      initialProps: baseProps,
+    })
+    rerender({ ...baseProps, isStale: true })
+    expect(result.current[0]).toBe('Weather data may be outdated')
+
+    // Re-rendering while still stale should not re-announce
+    act(() => result.current[1](''))
+    rerender({ ...baseProps, isStale: true })
+    expect(result.current[0]).toBe('')
+  })
+})

--- a/src/hooks/useStatusAnnouncement.ts
+++ b/src/hooks/useStatusAnnouncement.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react'
+import type { WeatherError } from '../types'
+
+interface StatusInputs {
+  isLoading: boolean
+  isRefreshing: boolean
+  isStale: boolean
+  error: WeatherError | null
+}
+
+/**
+ * Produces a polite live-region announcement string that reflects
+ * weather data status changes (loading, refresh complete, error, stale).
+ *
+ * - "Loading weather data" on transition into loading
+ * - "Weather data updated" once after a background refresh completes
+ * - "Error: <message>. Activate Try Again to retry." on a new error
+ * - "Weather data may be outdated" when entering a stale state
+ *
+ * The hook avoids repeated announcements by tracking previous state and
+ * only emitting when the relevant transition occurs.
+ */
+export function useStatusAnnouncement({ isLoading, isRefreshing, isStale, error }: StatusInputs): [string, (msg: string) => void] {
+  const [announcement, setAnnouncement] = useState('')
+  const prev = useRef({ isLoading: false, isRefreshing: false, isStale: false, error: null as WeatherError | null })
+
+  useEffect(() => {
+    const p = prev.current
+    if (isLoading && !p.isLoading) {
+      setAnnouncement('Loading weather data')
+    } else if (error && error !== p.error) {
+      setAnnouncement(`Error: ${error.message}. Activate Try Again to retry.`)
+    } else if (p.isRefreshing && !isRefreshing && !error) {
+      setAnnouncement('Weather data updated')
+    } else if (isStale && !p.isStale) {
+      setAnnouncement('Weather data may be outdated')
+    }
+    prev.current = { isLoading, isRefreshing, isStale, error }
+  }, [isLoading, isRefreshing, isStale, error])
+
+  return [announcement, setAnnouncement]
+}


### PR DESCRIPTION
Closes #14

## Summary
Extends the existing `aria-live="polite"` region in `App.tsx` to announce weather data status transitions to assistive tech, in addition to the current city-selection announcement.

## Implementation
- New hook **`src/hooks/useStatusAnnouncement.ts`** returns `[announcement, setAnnouncement]` and tracks previous state via ref so announcements fire only on transitions:
  - `isLoading` false → true: `Loading weather data`
  - new `error` (different reference): `Error: <message>. Activate Try Again to retry.`
  - `isRefreshing` true → false (and no error): `Weather data updated`
  - `isStale` false → true: `Weather data may be outdated`
- `App.tsx` wires `useWeather` outputs into the hook; the city-selection effect uses the returned setter to override the announcement when a new city is opened.
- The DOM (`<div className="sr-only" aria-live="polite" role="status">`) is unchanged — same node, richer content.

## Acceptance Criteria
- ✅ Loading state announced (`Loading weather data`)
- ✅ Error announced once with message + recovery action (`Try Again`)
- ✅ Refresh complete announced politely, not repeatedly

## Tests
- New `useStatusAnnouncement.test.ts` (7 tests) covers all four transitions, plus non-repetition guarantees:
  - Same error reference does not re-announce
  - Steady stale state does not re-announce
  - Refresh complete is suppressed when an error appears
- Full suite: **176 / 176 passing** (was 169 + 7 new).
- Build: clean, no TS errors.