### PR TITLE
feat(weather): richer weather details (precipitation, wind direction, daylight)

### DIFF
--- a/src/components/Dashboard.test.tsx
+++ b/src/components/Dashboard.test.tsx
@@ -194,6 +194,86 @@ describe('Dashboard', () => {
     expect(screen.getByText('Sunset')).toBeInTheDocument()
     expect(screen.getByText('Visibility')).toBeInTheDocument()
     expect(screen.getByText('Pressure')).toBeInTheDocument()
+    expect(screen.getByText('Wind Direction')).toBeInTheDocument()
+    expect(screen.getByText('Daylight')).toBeInTheDocument()
+    expect(screen.getByText('Precipitation')).toBeInTheDocument()
+    expect(screen.getByText('Precip. Chance')).toBeInTheDocument()
+  })
+
+  it('renders wind direction with compass label and degrees', () => {
+    render(
+      <Dashboard
+        current={{ ...mockCurrent, windDirection: 180 }}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={false}
+        isStale={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText(/S \(180°\)/)).toBeInTheDocument()
+  })
+
+  it('renders precipitation amount, chance, and daylight when provided', () => {
+    render(
+      <Dashboard
+        current={{
+          ...mockCurrent,
+          precipitation: 2.5,
+          precipitationChance: 73,
+          daylightDuration: 12 * 3600 + 30 * 60,
+        }}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={false}
+        isStale={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    // Imperial default: 2.5 mm → 0.1 in
+    expect(screen.getByText(/0\.1 in/)).toBeInTheDocument()
+    expect(screen.getByText(/73%/)).toBeInTheDocument()
+    expect(screen.getByText(/12h 30m/)).toBeInTheDocument()
+  })
+
+  it('shows Unavailable when optional details are missing', () => {
+    const sparse: typeof mockCurrent = {
+      ...mockCurrent,
+      windDirection: undefined,
+      precipitation: undefined,
+      precipitationChance: undefined,
+      daylightDuration: undefined,
+      visibility: undefined,
+    }
+    render(
+      <Dashboard
+        current={sparse}
+        forecast={mockForecast}
+        hourly={[]}
+        isLoading={false}
+        isRefreshing={false}
+        isStale={false}
+        error={null}
+        source="open-meteo"
+        onRetry={vi.fn()}
+        city={DEFAULT_CITY}
+        onCityChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('Unavailable').length).toBeGreaterThanOrEqual(5)
   })
 
   it('renders unit toggle in header', () => {

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,7 +19,7 @@ import { HourlyForecast } from './HourlyForecast'
 import { CityPicker } from './CityPicker'
 import { UnitToggle } from './UnitToggle'
 import { PanelSkeleton } from './PanelSkeleton'
-import { getStoredUnits, setStoredUnits, convertTemp, convertWindSpeed, convertVisibility, tempUnit, speedUnit, distanceUnit, type UnitSystem } from '../utils/units'
+import { getStoredUnits, setStoredUnits, convertTemp, convertWindSpeed, convertVisibility, convertPrecipitation, tempUnit, speedUnit, distanceUnit, precipitationUnit, formatDaylight, degreesToCompass, type UnitSystem } from '../utils/units'
 import { temperatureSummary, conditionsSummary, humiditySummary } from '../utils/chartSummaries'
 import './Dashboard.css'
 
@@ -432,12 +432,32 @@ export function Dashboard({ current, forecast, hourly, isLoading, isRefreshing, 
           <span className="info-value">{current.sunset}</span>
         </div>
         <div className="info-item">
+          <span className="info-label">Daylight</span>
+          <span className="info-value">{current.daylightDuration != null ? formatDaylight(current.daylightDuration) : 'Unavailable'}</span>
+        </div>
+        <div className="info-item">
           <span className="info-label">Visibility</span>
           <span className="info-value">{current.visibility != null ? `${convertVisibility(current.visibility, units)} ${distanceUnit(units)}` : 'Unavailable'}</span>
         </div>
         <div className="info-item">
           <span className="info-label">Pressure</span>
           <span className="info-value">{current.pressure} hPa</span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Wind Direction</span>
+          <span className="info-value">
+            {current.windDirection != null ? `${degreesToCompass(current.windDirection)} (${current.windDirection}°)` : 'Unavailable'}
+          </span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Precipitation</span>
+          <span className="info-value">
+            {current.precipitation != null ? `${convertPrecipitation(current.precipitation, units)} ${precipitationUnit(units)}` : 'Unavailable'}
+          </span>
+        </div>
+        <div className="info-item">
+          <span className="info-label">Precip. Chance</span>
+          <span className="info-value">{current.precipitationChance != null ? `${current.precipitationChance}%` : 'Unavailable'}</span>
         </div>
       </section>
     </div>

--- a/src/services/openMeteoApi.test.ts
+++ b/src/services/openMeteoApi.test.ts
@@ -83,6 +83,7 @@ describe('fetchOpenMeteoWeather', () => {
       wind_direction_10m: 225.4,
       visibility: 24140,
       uv_index: 5.3,
+      precipitation: 1.27,
     },
     daily: {
       time: ['2024-03-13', '2024-03-14', '2024-03-15', '2024-03-16', '2024-03-17', '2024-03-18'],
@@ -92,6 +93,8 @@ describe('fetchOpenMeteoWeather', () => {
       relative_humidity_2m_mean: [60, 55, 70, 65, 58, 62],
       sunrise: ['2024-03-13T06:30', '2024-03-14T06:29', '2024-03-15T06:28', '2024-03-16T06:27', '2024-03-17T06:26', '2024-03-18T06:25'],
       sunset: ['2024-03-13T19:45', '2024-03-14T19:46', '2024-03-15T19:47', '2024-03-16T19:48', '2024-03-17T19:49', '2024-03-18T19:50'],
+      precipitation_probability_max: [60, 40, 80, 20, 10, 5],
+      daylight_duration: [45000, 45100, 45200, 45300, 45400, 45500],
     },
     hourly: {
       time: Array.from({ length: 168 }, (_, i) => {
@@ -136,9 +139,35 @@ describe('fetchOpenMeteoWeather', () => {
     expect(result.current.uvIndex).toBe(5.3)
     expect(result.current.sunrise).toBe('6:30 AM')
     expect(result.current.sunset).toBe('7:45 PM')
+    expect(result.current.precipitation).toBe(1.3)
+    expect(result.current.precipitationChance).toBe(60)
+    expect(result.current.daylightDuration).toBe(45000)
     expect(result.forecast).toHaveLength(5)
     expect(result.forecast[0].conditions).toBe('Clear')
     expect(result.forecast[2].conditions).toBe('Rain')
+  })
+
+  it('returns undefined precipitation/daylight when daily arrays are absent', async () => {
+    const responseWithoutDailyExtras = {
+      ...mockOpenMeteoResponse,
+      current: { ...mockOpenMeteoResponse.current, precipitation: undefined },
+      daily: {
+        ...mockOpenMeteoResponse.daily,
+        precipitation_probability_max: undefined,
+        daylight_duration: undefined,
+      },
+    }
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(responseWithoutDailyExtras),
+    })
+
+    const result = await fetchOpenMeteoWeather(testCity)
+
+    expect(result.current.precipitation).toBeUndefined()
+    expect(result.current.precipitationChance).toBeUndefined()
+    expect(result.current.daylightDuration).toBeUndefined()
   })
 
   it('throws network error on non-ok response', async () => {

--- a/src/services/openMeteoApi.ts
+++ b/src/services/openMeteoApi.ts
@@ -69,6 +69,7 @@ interface OpenMeteoResponse {
     wind_direction_10m?: number
     visibility?: number
     uv_index?: number
+    precipitation?: number
   }
   daily: {
     time: string[]
@@ -78,6 +79,8 @@ interface OpenMeteoResponse {
     relative_humidity_2m_mean: number[]
     sunrise: string[]
     sunset: string[]
+    precipitation_probability_max?: number[]
+    daylight_duration?: number[]
   }
   hourly: {
     time: string[]
@@ -99,7 +102,7 @@ function formatHour(isoDateTime: string): string {
 
 export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): Promise<{ current: WeatherData; forecast: ForecastDay[]; hourly: HourlyForecast[] }> {
   try {
-    const url = `${BASE_URL}/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code,pressure_msl,apparent_temperature,wind_direction_10m,visibility,uv_index&hourly=temperature_2m,weather_code&daily=weather_code,temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,sunrise,sunset&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto`
+    const url = `${BASE_URL}/forecast?latitude=${city.lat}&longitude=${city.lon}&current=temperature_2m,relative_humidity_2m,wind_speed_10m,weather_code,pressure_msl,apparent_temperature,wind_direction_10m,visibility,uv_index,precipitation&hourly=temperature_2m,weather_code&daily=weather_code,temperature_2m_max,temperature_2m_min,relative_humidity_2m_mean,sunrise,sunset,precipitation_probability_max,daylight_duration&temperature_unit=fahrenheit&wind_speed_unit=mph&timezone=auto`
 
     const timeoutSignal = AbortSignal.timeout(10_000)
     const composedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
@@ -116,6 +119,13 @@ export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): P
     const feelsLike = data.current.apparent_temperature != null ? Math.round(data.current.apparent_temperature) : undefined
     const windDirection = data.current.wind_direction_10m != null ? Math.round(data.current.wind_direction_10m) : undefined
     const visibility = data.current.visibility != null ? Math.round(data.current.visibility / 1609) : undefined
+    const precipitation = data.current.precipitation != null ? Math.round(data.current.precipitation * 10) / 10 : undefined
+    const precipitationChance = data.daily.precipitation_probability_max?.[0] != null
+      ? Math.round(data.daily.precipitation_probability_max[0])
+      : undefined
+    const daylightDuration = data.daily.daylight_duration?.[0] != null
+      ? Math.round(data.daily.daylight_duration[0])
+      : undefined
 
     const current: WeatherData = {
       location: `${city.name}, ${city.country}`,
@@ -127,6 +137,9 @@ export async function fetchOpenMeteoWeather(city: City, signal?: AbortSignal): P
       ...(windDirection !== undefined && { windDirection }),
       ...(uvIndex !== undefined && { uvIndex }),
       ...(visibility !== undefined && { visibility }),
+      ...(precipitation !== undefined && { precipitation }),
+      ...(precipitationChance !== undefined && { precipitationChance }),
+      ...(daylightDuration !== undefined && { daylightDuration }),
       conditions: getConditionFromCode(data.current.weather_code),
       conditionIcon: '01d',
       sunrise: formatTimeFromIso(data.daily.sunrise[0] || ''),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,6 +157,9 @@ export interface WeatherData {
   windDirection?: number
   uvIndex?: number
   visibility?: number
+  precipitation?: number
+  precipitationChance?: number
+  daylightDuration?: number
   conditions: string
   conditionIcon: string
   sunrise: string

--- a/src/utils/units.test.ts
+++ b/src/utils/units.test.ts
@@ -3,9 +3,13 @@ import {
   convertTemp,
   convertWindSpeed,
   convertVisibility,
+  convertPrecipitation,
   tempUnit,
   speedUnit,
   distanceUnit,
+  precipitationUnit,
+  formatDaylight,
+  degreesToCompass,
   getStoredUnits,
   setStoredUnits,
 } from './units'
@@ -72,6 +76,97 @@ describe('unit conversion utilities', () => {
 
     it('returns km for metric', () => {
       expect(distanceUnit('metric')).toBe('km')
+    })
+  })
+
+  describe('convertPrecipitation', () => {
+    it('returns mm rounded to 1 decimal for metric', () => {
+      expect(convertPrecipitation(2.55, 'metric')).toBeCloseTo(2.6, 5)
+    })
+
+    it('returns 0 for 0 mm in either unit', () => {
+      expect(convertPrecipitation(0, 'metric')).toBe(0)
+      expect(convertPrecipitation(0, 'imperial')).toBe(0)
+    })
+
+    it('converts 25.4 mm to 1 in for imperial', () => {
+      expect(convertPrecipitation(25.4, 'imperial')).toBe(1)
+    })
+
+    it('converts 12.7 mm to 0.5 in for imperial', () => {
+      expect(convertPrecipitation(12.7, 'imperial')).toBe(0.5)
+    })
+  })
+
+  describe('precipitationUnit', () => {
+    it('returns mm for metric', () => {
+      expect(precipitationUnit('metric')).toBe('mm')
+    })
+
+    it('returns in for imperial', () => {
+      expect(precipitationUnit('imperial')).toBe('in')
+    })
+  })
+
+  describe('formatDaylight', () => {
+    it('formats 12h 0m', () => {
+      expect(formatDaylight(12 * 3600)).toBe('12h 0m')
+    })
+
+    it('formats 12h 30m', () => {
+      expect(formatDaylight(12 * 3600 + 30 * 60)).toBe('12h 30m')
+    })
+
+    it('rounds to nearest minute', () => {
+      expect(formatDaylight(12 * 3600 + 30 * 60 + 45)).toBe('12h 31m')
+    })
+
+    it('handles 0 seconds', () => {
+      expect(formatDaylight(0)).toBe('0h 0m')
+    })
+
+    it('returns -- for negative values', () => {
+      expect(formatDaylight(-1)).toBe('--')
+    })
+
+    it('returns -- for non-finite values', () => {
+      expect(formatDaylight(NaN)).toBe('--')
+      expect(formatDaylight(Infinity)).toBe('--')
+    })
+  })
+
+  describe('degreesToCompass', () => {
+    it.each([
+      [0, 'N'],
+      [45, 'NE'],
+      [90, 'E'],
+      [135, 'SE'],
+      [180, 'S'],
+      [225, 'SW'],
+      [270, 'W'],
+      [315, 'NW'],
+      [360, 'N'],
+    ])('maps %i° to %s', (deg, label) => {
+      expect(degreesToCompass(deg)).toBe(label)
+    })
+
+    it('rounds to nearest 8-point direction', () => {
+      expect(degreesToCompass(22)).toBe('N')
+      expect(degreesToCompass(23)).toBe('NE')
+      expect(degreesToCompass(67)).toBe('NE')
+      expect(degreesToCompass(68)).toBe('E')
+    })
+
+    it('normalizes negative degrees', () => {
+      expect(degreesToCompass(-45)).toBe('NW')
+    })
+
+    it('normalizes degrees over 360', () => {
+      expect(degreesToCompass(450)).toBe('E')
+    })
+
+    it('returns -- for non-finite values', () => {
+      expect(degreesToCompass(NaN)).toBe('--')
     })
   })
 

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -42,3 +42,42 @@ export function speedUnit(units: UnitSystem): string {
 export function distanceUnit(units: UnitSystem): string {
   return units === 'metric' ? 'km' : 'mi'
 }
+
+/**
+ * Convert precipitation amount.
+ * Open-Meteo is configured to return mm by default; we treat the input as mm
+ * and convert to inches for imperial.
+ */
+export function convertPrecipitation(mm: number, units: UnitSystem): number {
+  if (units === 'imperial') return Math.round((mm / 25.4) * 100) / 100
+  return Math.round(mm * 10) / 10
+}
+
+export function precipitationUnit(units: UnitSystem): string {
+  return units === 'metric' ? 'mm' : 'in'
+}
+
+/**
+ * Format a duration in seconds as a compact "Xh Ym" string.
+ * Returns "--" when the value is not a finite non-negative number.
+ */
+export function formatDaylight(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '--'
+  const totalMinutes = Math.round(seconds / 60)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return `${hours}h ${minutes}m`
+}
+
+const COMPASS_POINTS = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'] as const
+
+/**
+ * Convert a wind direction in meteorological degrees (0 = North, 90 = East)
+ * to an 8-point compass abbreviation.
+ */
+export function degreesToCompass(degrees: number): string {
+  if (!Number.isFinite(degrees)) return '--'
+  const normalized = ((degrees % 360) + 360) % 360
+  const index = Math.round(normalized / 45) % 8
+  return COMPASS_POINTS[index]
+}


### PR DESCRIPTION
Closes #21

## Summary
Surfaces three additional weather details from Open-Meteo and converts wind direction to a compass abbreviation:

- **Wind Direction** — N/NE/E/.../NW with degrees in parens
- **Precipitation** — current amount in mm/in based on unit toggle
- **Precip. Chance** — daily max probability for today (%)
- **Daylight** — duration today, formatted Xh Ym

All four render `Unavailable` when the upstream provider does not supply the value (matches the existing Visibility pattern), so the OpenWeatherMap fallback path still renders cleanly.

## Changes
- Extend `WeatherData` with three optional fields (no required-field changes; OWM path unaffected)
- Add Open-Meteo request params: `current=…,precipitation`, `daily=…,precipitation_probability_max,daylight_duration`
- New `utils/units` helpers: `convertPrecipitation`, `precipitationUnit`, `formatDaylight`, `degreesToCompass`
- Dashboard `additional-info` section gains 4 new info-items

## Tests
- 205 passing (was 176)
- Unit tests for all 4 new helpers (8-point compass + boundary normalization, formatDaylight rounding, precipitation conversion both directions)
- Open-Meteo parser tests for present + absent fields
- Dashboard tests for compass rendering, value rendering, and Unavailable fallback

## Verification
- `npm test -- --run` ✅ 205/205 passing
- `npm run build` ✅ clean (Mapbox chunk-size warning is pre-existing)