### PR TITLE
feat(dashboard): city background image hero in panel header

### DIFF
--- a/src/components/CityHero.css
+++ b/src/components/CityHero.css
@@ -1,0 +1,76 @@
+.city-hero {
+  position: relative;
+  width: 100%;
+  height: 160px;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 24px;
+  background: var(--card-bg, var(--bg));
+  border: 1px solid var(--border);
+  /* Reserve space immediately so there is no layout shift on load */
+  contain: layout paint;
+}
+
+.city-hero-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  opacity: 0;
+  transition: opacity 0.4s ease-out;
+}
+
+.city-hero.loaded .city-hero-img {
+  opacity: 1;
+}
+
+.city-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.15) 0%,
+    rgba(0, 0, 0, 0.05) 35%,
+    rgba(0, 0, 0, 0.45) 100%
+  );
+  pointer-events: none;
+}
+
+/* Subtle shimmer while the image is loading; hidden once loaded */
+.city-hero.loading::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.08) 50%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  animation: city-hero-shimmer 1.4s linear infinite;
+}
+
+@keyframes city-hero-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (max-width: 640px) {
+  .city-hero {
+    height: 130px;
+    margin-bottom: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .city-hero-img {
+    transition: none;
+  }
+
+  .city-hero.loading::before {
+    animation: none;
+  }
+}

--- a/src/components/CityHero.test.tsx
+++ b/src/components/CityHero.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CityHero } from './CityHero'
+import { DEFAULT_CITY } from '../types'
+import type { City } from '../types'
+
+describe('CityHero', () => {
+  it('renders an img with the city background URL', () => {
+    render(<CityHero city={DEFAULT_CITY} />)
+    const img = screen.getByRole('presentation', { hidden: true })
+    expect(img).toBeInTheDocument()
+    expect(img.getAttribute('src')).toBe(DEFAULT_CITY.backgroundImage)
+  })
+
+  it('uses empty alt and aria-hidden so the image is decorative', () => {
+    render(<CityHero city={DEFAULT_CITY} />)
+    const hero = screen.getByTestId('city-hero')
+    expect(hero).toHaveAttribute('aria-hidden', 'true')
+    const img = hero.querySelector('img')
+    expect(img).toHaveAttribute('alt', '')
+  })
+
+  it('renders the gradient overlay element', () => {
+    render(<CityHero city={DEFAULT_CITY} />)
+    expect(screen.getByTestId('city-hero').querySelector('.city-hero-overlay')).not.toBeNull()
+  })
+
+  it('starts in the loading state and switches to loaded after onLoad', () => {
+    render(<CityHero city={DEFAULT_CITY} />)
+    const hero = screen.getByTestId('city-hero')
+    expect(hero).toHaveClass('loading')
+    expect(hero).not.toHaveClass('loaded')
+
+    const img = hero.querySelector('img')!
+    fireEvent.load(img)
+
+    expect(hero).toHaveClass('loaded')
+    expect(hero).not.toHaveClass('loading')
+  })
+
+  it('renders nothing once the image fails to load', () => {
+    const { container } = render(<CityHero city={DEFAULT_CITY} />)
+    const img = container.querySelector('img')!
+    fireEvent.error(img)
+    expect(container.querySelector('[data-testid="city-hero"]')).toBeNull()
+  })
+
+  it('renders nothing when no city is supplied', () => {
+    const { container } = render(<CityHero city={null} />)
+    expect(container.querySelector('[data-testid="city-hero"]')).toBeNull()
+  })
+
+  it('renders nothing when the city has no backgroundImage', () => {
+    const cityNoImg: City = { ...DEFAULT_CITY, backgroundImage: '' }
+    const { container } = render(<CityHero city={cityNoImg} />)
+    expect(container.querySelector('[data-testid="city-hero"]')).toBeNull()
+  })
+
+  it('uses lazy loading on the image', () => {
+    render(<CityHero city={DEFAULT_CITY} />)
+    const img = screen.getByTestId('city-hero').querySelector('img')!
+    expect(img).toHaveAttribute('loading', 'lazy')
+  })
+})

--- a/src/components/CityHero.tsx
+++ b/src/components/CityHero.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import type { City } from '../types'
+import './CityHero.css'
+
+interface CityHeroProps {
+  city: City | null
+}
+
+type Status = 'loading' | 'loaded' | 'error'
+
+/**
+ * Hero banner showing a city-specific image with a dark gradient overlay so
+ * any text rendered on top stays readable. Renders nothing when no city is
+ * selected, when the city has no `backgroundImage`, or when the image fails
+ * to load — in those cases the surrounding animated WeatherBackground
+ * remains the only background, with no broken-image icon or layout shift.
+ */
+export function CityHero({ city }: CityHeroProps) {
+  const [status, setStatus] = useState<Status>('loading')
+
+  // Reset state whenever the city (and therefore the image URL) changes
+  useEffect(() => {
+    setStatus('loading')
+  }, [city?.id])
+
+  if (!city || !city.backgroundImage || status === 'error') {
+    return null
+  }
+
+  return (
+    <div
+      className={`city-hero ${status === 'loaded' ? 'loaded' : 'loading'}`}
+      aria-hidden="true"
+      data-testid="city-hero"
+    >
+      <img
+        className="city-hero-img"
+        src={city.backgroundImage}
+        alt=""
+        loading="lazy"
+        onLoad={() => setStatus('loaded')}
+        onError={() => setStatus('error')}
+      />
+      <div className="city-hero-overlay" />
+    </div>
+  )
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { HourlyForecast } from './HourlyForecast'
 import { CityPicker } from './CityPicker'
 import { UnitToggle } from './UnitToggle'
 import { PanelSkeleton } from './PanelSkeleton'
+import { CityHero } from './CityHero'
 import { getStoredUnits, setStoredUnits, convertTemp, convertWindSpeed, convertVisibility, convertPrecipitation, tempUnit, speedUnit, distanceUnit, precipitationUnit, formatDaylight, degreesToCompass, type UnitSystem } from '../utils/units'
 import { temperatureSummary, conditionsSummary, humiditySummary } from '../utils/chartSummaries'
 import './Dashboard.css'
@@ -296,6 +297,7 @@ export function Dashboard({ current, forecast, hourly, isLoading, isRefreshing, 
 
   return (
     <div className="dashboard">
+      <CityHero city={city} />
       <header className="dashboard-header">
         <div className="header-row">
           <div className="header-controls">


### PR DESCRIPTION
Closes #35

## Summary
Adds a hero/banner image at the top of the Dashboard, surfacing the previously unused `City.backgroundImage` Unsplash URLs.

- Lazy-loaded `<img>` with a dark linear-gradient overlay so existing text remains readable
- Container reserves space (160px desktop / 130px mobile) before image arrives → **no layout shift**
- On `onError`, the component returns `null` → **no broken-image icon**; the existing animated WeatherBackground remains the only background
- Subtle shimmer while loading; respects `prefers-reduced-motion`
- `aria-hidden="true"` + empty `alt` (the city is already announced by the panel header h2 and the existing live region)

## Acceptance criteria
- ✅ City image displays in panel header area (top of Dashboard inside WeatherPanel)
- ✅ Dark overlay gradient keeps text readable
- ✅ Graceful fallback to animated weather background on image load failure
- ✅ No layout shift (`contain: layout paint` + fixed container height)
- ✅ No broken image icon (component unmounts on error)

## Tests
- 213 passing total (was 205)
- 8 new `CityHero` tests: rendering, accessibility (`aria-hidden`, empty `alt`, `loading="lazy"`), state transitions, and 3 fallback paths (error / null city / empty URL)

## Verification
- `npm test -- --run` ✅ 213/213
- `npm run build` ✅ clean (Mapbox chunk warning is pre-existing)