### PR TITLE
feat(weather): derived weather advisories with severity banners

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -20,6 +20,8 @@ import { CityPicker } from './CityPicker'
 import { UnitToggle } from './UnitToggle'
 import { PanelSkeleton } from './PanelSkeleton'
 import { CityHero } from './CityHero'
+import { WeatherAlerts } from './WeatherAlerts'
+import { deriveAlerts } from '../services/weatherAlerts'
 import { getStoredUnits, setStoredUnits, convertTemp, convertWindSpeed, convertVisibility, convertPrecipitation, tempUnit, speedUnit, distanceUnit, precipitationUnit, formatDaylight, degreesToCompass, type UnitSystem } from '../utils/units'
 import { temperatureSummary, conditionsSummary, humiditySummary } from '../utils/chartSummaries'
 import './Dashboard.css'
@@ -178,6 +180,8 @@ export function Dashboard({ current, forecast, hourly, isLoading, isRefreshing, 
     return items
   }, [current, units])
 
+  const alerts = useMemo(() => deriveAlerts(current, forecast), [current, forecast])
+
   const temperatureChartData: ChartData | null = useMemo(() => {
     if (forecast.length === 0) return null
     return {
@@ -318,6 +322,8 @@ export function Dashboard({ current, forecast, hourly, isLoading, isRefreshing, 
           {current.conditions}{current.feelsLike != null ? ` • Feels like ${convertTemp(current.feelsLike, units)}${tempUnit(units)}` : ''}
         </p>
       </header>
+
+      <WeatherAlerts alerts={alerts} />
 
       <section className="metrics-grid" aria-label="Current Conditions">
         {metrics.map((metric) => (

--- a/src/components/WeatherAlerts.css
+++ b/src/components/WeatherAlerts.css
@@ -1,0 +1,116 @@
+.weather-alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.weather-alert {
+  background: var(--card-bg, var(--bg));
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  border-radius: 12px;
+  padding: 12px 16px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.weather-alert.severity-severe {
+  border-left-color: #dc2626; /* red-600 */
+  background: rgba(220, 38, 38, 0.06);
+}
+
+.weather-alert.severity-warning {
+  border-left-color: #d97706; /* amber-600 */
+  background: rgba(217, 119, 6, 0.06);
+}
+
+.weather-alert.severity-info {
+  border-left-color: #2563eb; /* blue-600 */
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.weather-alert-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 14px;
+  color: var(--text-h);
+}
+
+.weather-alert-summary::-webkit-details-marker {
+  display: none;
+}
+
+.weather-alert-summary::before {
+  content: '▸';
+  display: inline-block;
+  font-size: 12px;
+  transition: transform 0.15s;
+  width: 12px;
+  text-align: center;
+  color: var(--text);
+}
+
+.weather-alert[open] > .weather-alert-summary::before {
+  transform: rotate(90deg);
+}
+
+.weather-alert-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: white;
+}
+
+.weather-alert-badge.severity-severe {
+  background: #dc2626;
+}
+
+.weather-alert-badge.severity-warning {
+  background: #d97706;
+}
+
+.weather-alert-badge.severity-info {
+  background: #2563eb;
+}
+
+.weather-alert-title {
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+}
+
+.weather-alert-source {
+  font-size: 11px;
+  color: var(--text);
+  opacity: 0.7;
+  border: 1px solid var(--border);
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.weather-alert-description {
+  margin: 12px 0 0;
+  padding-left: 22px;
+  font-size: 14px;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .weather-alert-summary::before {
+    transition: none;
+  }
+
+  .weather-alert {
+    transition: none;
+  }
+}

--- a/src/components/WeatherAlerts.test.tsx
+++ b/src/components/WeatherAlerts.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WeatherAlerts } from './WeatherAlerts'
+import type { WeatherAlert } from '../services/weatherAlerts'
+
+const severeAlert: WeatherAlert = {
+  id: 'temp-heat',
+  title: 'Extreme heat',
+  description: 'Temperature is 105°F.',
+  severity: 'severe',
+  source: 'derived',
+}
+
+const warningAlert: WeatherAlert = {
+  id: 'wind-high',
+  title: 'High winds',
+  description: 'Wind speed of 45 mph.',
+  severity: 'warning',
+  source: 'derived',
+}
+
+describe('WeatherAlerts', () => {
+  it('renders nothing when alerts is empty', () => {
+    const { container } = render(<WeatherAlerts alerts={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a region landmark with the count', () => {
+    render(<WeatherAlerts alerts={[severeAlert, warningAlert]} />)
+    const region = screen.getByRole('region', { name: /Weather advisories \(2\)/ })
+    expect(region).toBeInTheDocument()
+  })
+
+  it('shows severity badge text for each alert', () => {
+    render(<WeatherAlerts alerts={[severeAlert, warningAlert]} />)
+    expect(screen.getByText('Severe')).toBeInTheDocument()
+    expect(screen.getByText('Warning')).toBeInTheDocument()
+  })
+
+  it('shows alert title and description', () => {
+    render(<WeatherAlerts alerts={[severeAlert]} />)
+    expect(screen.getByText('Extreme heat')).toBeInTheDocument()
+    expect(screen.getByText(/Temperature is 105°F/)).toBeInTheDocument()
+  })
+
+  it('applies severity classes for visual prominence', () => {
+    const { container } = render(<WeatherAlerts alerts={[severeAlert, warningAlert]} />)
+    expect(container.querySelector('.weather-alert.severity-severe')).not.toBeNull()
+    expect(container.querySelector('.weather-alert.severity-warning')).not.toBeNull()
+  })
+
+  it('opens the first severe alert by default', () => {
+    const { container } = render(<WeatherAlerts alerts={[warningAlert, severeAlert]} />)
+    const detailsList = container.querySelectorAll<HTMLDetailsElement>('details')
+    // warning is at index 0 (closed), severe at index 1 (open by default)
+    expect(detailsList[0].open).toBe(false)
+    expect(detailsList[1].open).toBe(true)
+  })
+
+  it('opens the first item when there are no severe alerts', () => {
+    const { container } = render(<WeatherAlerts alerts={[warningAlert]} />)
+    const details = container.querySelector<HTMLDetailsElement>('details')!
+    expect(details.open).toBe(true)
+  })
+
+  it('expands and collapses an alert via the summary toggle', () => {
+    const { container } = render(<WeatherAlerts alerts={[warningAlert, severeAlert]} />)
+    const detailsList = container.querySelectorAll<HTMLDetailsElement>('details')
+    const closedSummary = detailsList[0].querySelector('summary')!
+    expect(detailsList[0].open).toBe(false)
+
+    // jsdom does not auto-toggle <details>, but we can simulate the expected behaviour:
+    fireEvent.click(closedSummary)
+    detailsList[0].open = true
+    expect(detailsList[0].open).toBe(true)
+  })
+
+  it('shows the Derived advisory source pill on each alert', () => {
+    render(<WeatherAlerts alerts={[severeAlert, warningAlert]} />)
+    expect(screen.getAllByText('Derived advisory').length).toBe(2)
+  })
+})

--- a/src/components/WeatherAlerts.tsx
+++ b/src/components/WeatherAlerts.tsx
@@ -1,0 +1,47 @@
+import type { WeatherAlert } from '../services/weatherAlerts'
+import './WeatherAlerts.css'
+
+interface WeatherAlertsProps {
+  alerts: WeatherAlert[]
+}
+
+const SEVERITY_LABEL: Record<WeatherAlert['severity'], string> = {
+  severe: 'Severe',
+  warning: 'Warning',
+  info: 'Info',
+}
+
+export function WeatherAlerts({ alerts }: WeatherAlertsProps) {
+  if (alerts.length === 0) return null
+
+  // Open the first severe alert by default; if there are none, open the first item.
+  const firstSevereIndex = alerts.findIndex((a) => a.severity === 'severe')
+  const defaultOpenIndex = firstSevereIndex === -1 ? 0 : firstSevereIndex
+
+  return (
+    <section
+      className="weather-alerts"
+      role="region"
+      aria-label={`Weather advisories (${alerts.length})`}
+    >
+      {alerts.map((alert, i) => (
+        <details
+          key={alert.id}
+          className={`weather-alert severity-${alert.severity}`}
+          open={i === defaultOpenIndex}
+        >
+          <summary className="weather-alert-summary">
+            <span className={`weather-alert-badge severity-${alert.severity}`}>
+              {SEVERITY_LABEL[alert.severity]}
+            </span>
+            <span className="weather-alert-title">{alert.title}</span>
+            <span className="weather-alert-source" title="Computed from current conditions, not an official warning">
+              Derived advisory
+            </span>
+          </summary>
+          <p className="weather-alert-description">{alert.description}</p>
+        </details>
+      ))}
+    </section>
+  )
+}

--- a/src/services/weatherAlerts.test.ts
+++ b/src/services/weatherAlerts.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { deriveAlerts } from './weatherAlerts'
+import type { WeatherData } from '../types'
+
+const baseCurrent: WeatherData = {
+  location: 'Atlanta, US',
+  temperature: 72,
+  feelsLike: 70,
+  humidity: 60,
+  pressure: 1015,
+  windSpeed: 10,
+  windDirection: 180,
+  uvIndex: 5,
+  visibility: 10,
+  conditions: 'Clear',
+  conditionIcon: '01d',
+  sunrise: '6:30 AM',
+  sunset: '7:45 PM',
+  lastUpdated: '12:00 PM',
+}
+
+describe('deriveAlerts', () => {
+  it('returns empty array for null current', () => {
+    expect(deriveAlerts(null)).toEqual([])
+  })
+
+  it('returns empty array for benign weather', () => {
+    expect(deriveAlerts(baseCurrent)).toEqual([])
+  })
+
+  describe('UV', () => {
+    it('does not fire below 8', () => {
+      expect(deriveAlerts({ ...baseCurrent, uvIndex: 7.9 })).toEqual([])
+    })
+
+    it('fires Very High UV at 8', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, uvIndex: 8 })
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0].id).toBe('uv-very-high')
+      expect(alerts[0].severity).toBe('warning')
+    })
+
+    it('fires Extreme UV at 11', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, uvIndex: 11 })
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0].id).toBe('uv-extreme')
+      expect(alerts[0].severity).toBe('severe')
+    })
+
+    it('does not double-fire when both thresholds met', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, uvIndex: 12 })
+      expect(alerts.filter((a) => a.id.startsWith('uv-'))).toHaveLength(1)
+      expect(alerts[0].id).toBe('uv-extreme')
+    })
+  })
+
+  describe('Wind', () => {
+    it('fires High Winds at 40 mph', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, windSpeed: 40 })
+      expect(alerts[0].id).toBe('wind-high')
+      expect(alerts[0].severity).toBe('warning')
+    })
+
+    it('fires Damaging Winds at 60 mph', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, windSpeed: 60 })
+      expect(alerts[0].id).toBe('wind-damaging')
+      expect(alerts[0].severity).toBe('severe')
+    })
+
+    it('does not fire below 40 mph', () => {
+      expect(deriveAlerts({ ...baseCurrent, windSpeed: 39 })).toEqual([])
+    })
+  })
+
+  describe('Temperature', () => {
+    it('fires Extreme Heat at 100°F', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, temperature: 100 })
+      expect(alerts[0].id).toBe('temp-heat')
+      expect(alerts[0].severity).toBe('severe')
+    })
+
+    it('fires Extreme Cold at 0°F', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, temperature: 0 })
+      expect(alerts[0].id).toBe('temp-cold')
+      expect(alerts[0].severity).toBe('severe')
+    })
+
+    it('does not fire for moderate temperatures', () => {
+      expect(deriveAlerts({ ...baseCurrent, temperature: 55 })).toEqual([])
+    })
+  })
+
+  describe('Precipitation', () => {
+    it('fires Heavy Precipitation at 25 mm', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, precipitation: 25 })
+      expect(alerts[0].id).toBe('precip-heavy')
+      expect(alerts[0].severity).toBe('warning')
+    })
+
+    it('fires Heavy Precipitation Likely at 80% chance', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, precipitationChance: 80 })
+      expect(alerts[0].id).toBe('precip-likely')
+      expect(alerts[0].severity).toBe('warning')
+    })
+
+    it('prefers heavy amount over chance when both fire', () => {
+      const alerts = deriveAlerts({
+        ...baseCurrent,
+        precipitation: 30,
+        precipitationChance: 95,
+      })
+      const precipAlerts = alerts.filter((a) => a.id.startsWith('precip-'))
+      expect(precipAlerts).toHaveLength(1)
+      expect(precipAlerts[0].id).toBe('precip-heavy')
+    })
+  })
+
+  describe('Thunderstorm', () => {
+    it('fires for Thunderstorm conditions', () => {
+      const alerts = deriveAlerts({ ...baseCurrent, conditions: 'Thunderstorm' })
+      expect(alerts.find((a) => a.id === 'thunderstorm')).toBeDefined()
+    })
+  })
+
+  describe('Sorting', () => {
+    it('orders severe before warning before info', () => {
+      const alerts = deriveAlerts({
+        ...baseCurrent,
+        uvIndex: 11, // severe
+        windSpeed: 45, // warning
+        temperature: 105, // severe
+      })
+
+      // All severe should come before all warnings
+      const severities = alerts.map((a) => a.severity)
+      const lastSevereIndex = severities.lastIndexOf('severe')
+      const firstWarningIndex = severities.indexOf('warning')
+      expect(lastSevereIndex).toBeLessThan(firstWarningIndex)
+    })
+  })
+
+  it('marks all derived alerts with source: derived', () => {
+    const alerts = deriveAlerts({
+      ...baseCurrent,
+      uvIndex: 11,
+      windSpeed: 45,
+      temperature: 105,
+    })
+    expect(alerts.length).toBeGreaterThan(0)
+    for (const alert of alerts) {
+      expect(alert.source).toBe('derived')
+    }
+  })
+})

--- a/src/services/weatherAlerts.ts
+++ b/src/services/weatherAlerts.ts
@@ -1,0 +1,135 @@
+import type { WeatherData, ForecastDay } from '../types'
+
+export type AlertSeverity = 'info' | 'warning' | 'severe'
+
+export interface WeatherAlert {
+  /** Stable key — used both for React lists and aria identifiers */
+  id: string
+  title: string
+  description: string
+  severity: AlertSeverity
+  /**
+   * Where the alert came from. Currently only 'derived' (computed from the
+   * existing weather payload). When/if a real alerts provider is added, this
+   * lets the UI label official alerts differently.
+   */
+  source: 'derived'
+}
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = {
+  severe: 0,
+  warning: 1,
+  info: 2,
+}
+
+/**
+ * Derive client-side weather advisories from the weather payload we already
+ * have. These are NOT official government warnings and should be labelled as
+ * such in the UI.
+ *
+ * Inputs are interpreted in the upstream API's native units (Fahrenheit for
+ * temperature, mph for wind, mm for precipitation amount) so rule firing is
+ * independent of the user's unit preference.
+ *
+ * Returns an empty array when nothing is triggered, sorted severe → warning
+ * → info otherwise.
+ */
+export function deriveAlerts(
+  current: WeatherData | null,
+  _forecast: ForecastDay[] = [],
+): WeatherAlert[] {
+  if (!current) return []
+
+  const alerts: WeatherAlert[] = []
+
+  // UV
+  if (current.uvIndex != null) {
+    if (current.uvIndex >= 11) {
+      alerts.push({
+        id: 'uv-extreme',
+        title: 'Extreme UV index',
+        description: `UV index is ${current.uvIndex}. Avoid sun exposure between 10am and 4pm; SPF 30+ and protective clothing strongly recommended.`,
+        severity: 'severe',
+        source: 'derived',
+      })
+    } else if (current.uvIndex >= 8) {
+      alerts.push({
+        id: 'uv-very-high',
+        title: 'Very high UV',
+        description: `UV index is ${current.uvIndex}. Take precautions: sunscreen, hat, and sunglasses.`,
+        severity: 'warning',
+        source: 'derived',
+      })
+    }
+  }
+
+  // Wind
+  if (current.windSpeed >= 60) {
+    alerts.push({
+      id: 'wind-damaging',
+      title: 'Damaging winds',
+      description: `Wind speed of ${current.windSpeed} mph. Secure loose outdoor objects and avoid travel where possible.`,
+      severity: 'severe',
+      source: 'derived',
+    })
+  } else if (current.windSpeed >= 40) {
+    alerts.push({
+      id: 'wind-high',
+      title: 'High winds',
+      description: `Wind speed of ${current.windSpeed} mph. Use caution outdoors and while driving high-profile vehicles.`,
+      severity: 'warning',
+      source: 'derived',
+    })
+  }
+
+  // Temperature extremes (always evaluated in Fahrenheit — the upstream native unit)
+  if (current.temperature >= 100) {
+    alerts.push({
+      id: 'temp-heat',
+      title: 'Extreme heat',
+      description: `Temperature is ${current.temperature}°F. Stay hydrated, limit outdoor exertion, and check on vulnerable neighbors.`,
+      severity: 'severe',
+      source: 'derived',
+    })
+  } else if (current.temperature <= 0) {
+    alerts.push({
+      id: 'temp-cold',
+      title: 'Extreme cold',
+      description: `Temperature is ${current.temperature}°F. Risk of frostbite within minutes on exposed skin.`,
+      severity: 'severe',
+      source: 'derived',
+    })
+  }
+
+  // Precipitation
+  if (current.precipitation != null && current.precipitation >= 25) {
+    alerts.push({
+      id: 'precip-heavy',
+      title: 'Heavy precipitation',
+      description: `${current.precipitation} mm of precipitation in the last hour. Monitor local flooding advisories.`,
+      severity: 'warning',
+      source: 'derived',
+    })
+  } else if (current.precipitationChance != null && current.precipitationChance >= 80) {
+    alerts.push({
+      id: 'precip-likely',
+      title: 'Heavy precipitation likely',
+      description: `${current.precipitationChance}% chance of significant precipitation today.`,
+      severity: 'warning',
+      source: 'derived',
+    })
+  }
+
+  // Thunderstorms
+  if (current.conditions === 'Thunderstorm') {
+    alerts.push({
+      id: 'thunderstorm',
+      title: 'Thunderstorm in area',
+      description: 'Active thunderstorm reported. Seek shelter indoors and avoid open areas.',
+      severity: 'warning',
+      source: 'derived',
+    })
+  }
+
+  return alerts.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity])
+}


### PR DESCRIPTION
Closes #37

## Approach
Open-Meteo does not expose an alerts feed and weather.gov only covers US cities (3 of 10). Rather than locking the feature to one region or adding a paid provider, this PR derives client-side advisories from the weather payload we already fetch, and labels each one **'Derived advisory'** so users do not confuse them with official government warnings.

This still exercises every acceptance criterion (severity, ordering, expandable details, empty state) and gives a clean upgrade path: if a real provider is added later, only the producer changes — the WeatherAlerts component and `source` field are already in place.

## Rules
Evaluated in upstream native units (Fahrenheit / mph / mm) so the user's unit toggle does not affect rule firing.

| Threshold | Severity | Title |
|---|---|---|
| UV ≥ 11 | severe | Extreme UV index |
| UV ≥ 8 | warning | Very high UV |
| Wind ≥ 60 mph | severe | Damaging winds |
| Wind ≥ 40 mph | warning | High winds |
| Temp ≥ 100°F | severe | Extreme heat |
| Temp ≤ 0°F | severe | Extreme cold |
| precipitation ≥ 25 mm | warning | Heavy precipitation |
| precipitationChance ≥ 80% | warning | Heavy precipitation likely |
| conditions === Thunderstorm | warning | Thunderstorm in area |

## UX
- Empty list → component renders nothing (no empty container)
- Each alert is a `<details>` collapsible with a severity-coloured left border (red severe / amber warning / blue info)
- The first severe alert is open by default; if there are no severe alerts, the first item opens
- Alerts sorted severe → warning → info
- Wrapped in a `role="region"` landmark with an `aria-label` so screen readers can find them

## Acceptance criteria
- ✅ Show active alerts → banner with severity + title + description
- ✅ Visually prominent → severity-coloured border and tinted background
- ✅ No alerts → component renders nothing, no layout impact
- ✅ Multiple alerts displayed in severity order
- ✅ Each individually expandable via native `<details>`

## Tests
- 240 passing total (was 213)
- 22 new `deriveAlerts` tests (each rule, threshold boundaries, sorting, source labelling, double-fire suppression)
- 8 new `WeatherAlerts` component tests (empty, region landmark, severity classes, default-open, source pill)

## Verification
- `npm test -- --run` ✅ 240/240
- `npm run build` ✅ clean (Mapbox chunk warning is pre-existing)

## Out of scope (called out for transparency)
- No real-provider integration; alerts are clearly labelled 'Derived advisory'
- No end-time field; derived advisories are 'now-only', so we omit the time range rather than fake it