### PR TITLE
perf(map): lazy-load Mapbox to remove ~452 kB gzipped from critical path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback, useEffect, useMemo, useRef, lazy, Suspense } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
-import { MapView } from './components/MapView'
 import { WeatherPanel } from './components/WeatherPanel'
 import { InvalidCityView } from './components/InvalidCityView'
 import { PanelSkeleton } from './components/PanelSkeleton'
+import { MapSkeleton } from './components/MapSkeleton'
 import { useWeather } from './hooks/useWeather'
 import { useStatusAnnouncement } from './hooks/useStatusAnnouncement'
 import { CITIES, DEFAULT_CITY, type City } from './types'
@@ -11,6 +11,7 @@ import { getCityById } from './utils/cityUrl'
 import './App.css'
 
 const Dashboard = lazy(() => import('./components/Dashboard').then((m) => ({ default: m.Dashboard })))
+const MapView = lazy(() => import('./components/MapView').then((m) => ({ default: m.MapView })))
 
 function App() {
   const { cityId } = useParams<{ cityId?: string }>()
@@ -80,12 +81,14 @@ function App() {
 
   return (
     <>
-      <MapView
-        selectedCityId={selectedCity?.id ?? null}
-        onCitySelect={handleCitySelect}
-        onDeselect={handlePanelClose}
-        markerRefs={markerRefs}
-      />
+      <Suspense fallback={<MapSkeleton />}>
+        <MapView
+          selectedCityId={selectedCity?.id ?? null}
+          onCitySelect={handleCitySelect}
+          onDeselect={handlePanelClose}
+          markerRefs={markerRefs}
+        />
+      </Suspense>
       <WeatherPanel
         isOpen={selectedCity !== null || invalidCityId !== null}
         onClose={handlePanelClose}

--- a/src/components/MapSkeleton.css
+++ b/src/components/MapSkeleton.css
@@ -1,0 +1,41 @@
+.map-skeleton {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.06), transparent 50%),
+    linear-gradient(180deg, #1a3c6e 0%, #2563a8 60%, #3b82d4 100%);
+  overflow: hidden;
+}
+
+.map-skeleton-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.04) 50%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  animation: map-skeleton-shimmer 2.4s linear infinite;
+}
+
+@keyframes map-skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .map-skeleton {
+    background:
+      radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.04), transparent 50%),
+      linear-gradient(180deg, #0f1d36 0%, #142a52 60%, #1d3a72 100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-skeleton-shimmer {
+    animation: none;
+  }
+}

--- a/src/components/MapSkeleton.test.tsx
+++ b/src/components/MapSkeleton.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MapSkeleton } from './MapSkeleton'
+
+describe('MapSkeleton', () => {
+  it('renders a status landmark with an accessible name', () => {
+    render(<MapSkeleton />)
+    const status = screen.getByRole('status', { name: 'Loading map' })
+    expect(status).toBeInTheDocument()
+  })
+
+  it('renders a shimmer element marked aria-hidden', () => {
+    const { container } = render(<MapSkeleton />)
+    const shimmer = container.querySelector('.map-skeleton-shimmer')
+    expect(shimmer).not.toBeNull()
+    expect(shimmer).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/src/components/MapSkeleton.tsx
+++ b/src/components/MapSkeleton.tsx
@@ -1,0 +1,19 @@
+import './MapSkeleton.css'
+
+/**
+ * Lightweight placeholder shown while the heavy `mapbox-gl` chunk loads.
+ * Has zero JS dependencies of its own so it ships with the eager bundle and
+ * paints immediately, preventing layout shift when the real map mounts.
+ */
+export function MapSkeleton() {
+  return (
+    <div
+      className="map-skeleton"
+      role="status"
+      aria-label="Loading map"
+      data-testid="map-skeleton"
+    >
+      <div className="map-skeleton-shimmer" aria-hidden="true" />
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #77

## Summary
`MapView` now loads via `React.lazy`, with a tiny pure-CSS `MapSkeleton` as the Suspense fallback. The 1.6 MB `mapbox-gl` chunk and the 42 KB MapView CSS are no longer statically imported from the entry — neither appears in the rendered `index.html` modulepreload list, and the entry JS no longer references them.

## Bundle impact (production build)

| Chunk | Before | After | Notes |
|---|---|---|---|
| `index-*.js` (eager) | 271 kB / **87 kB gz** | 239 kB / **77 kB gz** | -10 kB gz |
| `mapbox-gl-*.js` | 1666 kB / **452 kB gz** *(eager)* | 1666 kB / 452 kB gz *(lazy)* | no longer blocks LCP |
| `MapView-*.css` | bundled into eager CSS | 42 kB / 6 kB gz *(lazy)* | new |
| `MapView-*.js` | (n/a) | 22 kB / 8 kB gz *(lazy)* | new |
| `Dashboard-*.js` | 208 kB / 71 kB gz | 208 kB / 71 kB gz | already lazy |

**Net effect on first paint**: roughly **470 kB gzipped** of JS+CSS that previously loaded on every visit is now deferred until the user actually needs the map. The MapSkeleton paints immediately, fills the same fixed container, and respects `prefers-reduced-motion` and `prefers-color-scheme`, so there's no layout shift when the real map swaps in.

## Verification
- `grep mapbox-gl dist/assets/index-*.js` → **0 matches** (was 2)
- `dist/index.html` no longer modulepreloads mapbox
- `npm test -- --run` → **242/242** passing (was 240, +2 MapSkeleton tests)
- `npm run build` → clean (Vite chunk-size warning still triggers because mapbox-gl itself is large, but the warning is now informational rather than affecting first paint)

## Acceptance criteria
- ✅ Mapbox excluded from eager bundle (no static import from entry)
- ✅ Map placeholder paints on first paint, no layout shift
- ✅ Dashboard panel renders without waiting for mapbox-gl
- ✅ City selection still works once map loads