### PR TITLE
docs: refresh case study + README for current features and lazy-Mapbox perf win

### DIFF
--- a/CASE_STUDY.md
+++ b/CASE_STUDY.md
@@ -1,42 +1,69 @@
 # Weather Teardown — Case Study
 
 ## Overview
-An interactive weather dashboard built with React 19, TypeScript, and Mapbox GL. Features a full-screen globe with city markers, a sliding weather panel with real-time conditions and 5-day forecast charts, responsive mobile bottom-sheet with swipe gestures, and full keyboard/screen-reader accessibility.
+An interactive weather dashboard built with React 19, TypeScript, and Mapbox GL. A full-screen globe with city markers leads into a sliding weather panel that surfaces real-time conditions, derived weather advisories, hourly and 5-day forecast charts, and rich location details (sunrise/sunset, daylight duration, compass wind direction, visibility, precipitation amount and chance). The UI is responsive — a swipe-dismissable bottom-sheet on mobile — and fully keyboard- and screen-reader-accessible, including an `aria-live` status region that announces loading, refresh, stale, and error transitions.
 
 ## Tech Stack
-- **Framework**: React 19.2.4 + TypeScript 5.9.3
-- **Build Tool**: Vite 8.0.0
-- **Map**: Mapbox GL JS 3 + react-map-gl 8
+- **Framework**: React 19.2 + TypeScript 5.9 (strict)
+- **Build Tool**: Vite 8
+- **Map**: Mapbox GL JS 3 + react-map-gl 8 (lazy-loaded)
 - **Charts**: Chart.js 4.5 + react-chartjs-2
-- **Unit Testing**: Vitest 4.1 + React Testing Library 16
+- **Routing**: react-router-dom 7
+- **Unit Testing**: Vitest 4 + React Testing Library 16
 - **E2E Testing**: Playwright 1.58
 - **CI**: GitHub Actions
 - **Deployment**: Vercel
 
 ## Features
-- Full-screen interactive Mapbox globe with custom-styled layers
-- 10 city markers with keyboard navigation and pulse animation
-- Real-time weather via Open-Meteo with offline fallback to mock data
-- 5-day forecast with temperature trend charts
-- Unit toggle (°F/°C, mph/km/h)
+- Full-screen interactive Mapbox globe with custom-styled water, land, landcover, and admin-boundary layers
+- 10 city markers with keyboard navigation, ARIA semantics, and pulse animation on selection
+- Real-time weather via Open-Meteo, with OpenWeatherMap and an offline mock as graceful fallbacks
+- Hourly and 5-day forecast charts (Chart.js) with `<table class="sr-only">` data tables for screen readers
+- Rich current conditions: temperature, feels-like, humidity, UV, wind speed/direction (compass), visibility, pressure, precipitation amount/chance, sunrise/sunset, daylight duration — every optional field renders an "Unavailable" fallback rather than disappearing
+- **Derived weather advisories**: client-side severity-coloured banners (severe / warning / info) for UV, wind, temperature extremes, precipitation, and thunderstorms — clearly labelled "Derived advisory" so they aren't confused with official government warnings
+- **City hero banner**: lazy-loaded location image with dark gradient overlay; fixed-height container avoids CLS, errors silently fall back to the animated weather background
+- Unit toggle (°F/°C, mph/km/h) persisted to localStorage
 - Responsive bottom-sheet panel with swipe-to-dismiss on mobile
-- ARIA labels, focus management, and live regions for accessibility
-- URL sync via `?city=<id>` query params for shareable links
+- Shareable city URLs via `/city/:cityId` route (with legacy `?city=` redirect)
+- `aria-live` polite region announces loading / refreshing / stale / error / city-selected transitions
+
+## Performance Teardown — Lazy-loaded Mapbox
+
+The original build statically imported `mapbox-gl`, putting the entire 1.6 MB map engine and its CSS on the critical path of every page load — even though nothing on the page is interactive until the user picks a city. Splitting `MapView` and `Dashboard` behind `React.lazy` removes Mapbox (and its stylesheet) from the eager bundle and the `<link rel="modulepreload">` graph in `index.html`.
+
+| Asset                  | Before (raw / gz)        | After (raw / gz)         | Δ gzipped       |
+| ---------------------- | ------------------------ | ------------------------ | --------------- |
+| Eager `index-*.js`     | 271 kB / 87 kB           | 239 kB / **77 kB**       | **−10 kB**      |
+| `mapbox-gl-*.js`       | bundled into eager chunk | 1,666 kB / 452 kB (lazy) | off LCP path    |
+| `MapView-*.css`        | bundled into eager CSS   | 42 kB / 6 kB (lazy)      | off LCP path    |
+| `Dashboard-*.js`       | bundled into eager chunk | 208 kB / 71 kB (lazy)    | off LCP path    |
+
+Net effect: **~470 kB gzipped of JS + CSS** no longer blocks LCP on first paint. While the map chunk is fetching, a zero-dependency `<MapSkeleton>` paints immediately so the layout is stable and the panel/route transitions remain interactive.
+
+Verified post-build:
+- `grep mapbox-gl dist/assets/index-*.js` → **0 matches** (was 2 before the split)
+- `dist/index.html` no longer `modulepreload`s the mapbox chunk
+
+Vite still warns about the >500 kB Mapbox chunk; that warning is now informational because the chunk is no longer eager.
 
 ## Quality Metrics
-- **Bundle Size**: 139 KB JS gzipped (+ 452 KB Mapbox GL)
-- **Tests**: 63 passing (Vitest + React Testing Library)
+- **Eager JS**: 239 kB raw / **77 kB gzipped** (`index-*.js`)
+- **Lazy chunks**: `Dashboard` (208 kB / 71 kB gz), `MapView` (22 kB / 8 kB gz), `mapbox-gl` (1,666 kB / 452 kB gz)
+- **Tests**: **242 passing** across 21 Vitest files (unit + component); Playwright E2E in CI
 - **Lint**: 0 errors (ESLint 9.39)
-- **TypeScript**: Strict mode enabled, 0 errors
-- **CI**: Lint, typecheck, test, build on every PR
+- **TypeScript**: strict mode, 0 errors
+- **CI**: lint, typecheck, test, build on every PR
 
 ## Links
 - **Live Demo**: https://performance-teardown-demo.vercel.app
 - **Repository**: https://github.com/andysolomon/performance-teardown-demo
 
 ## Key Decisions
-1. **Mapbox GL over Leaflet**: Selected for globe projection, custom layer styling, and smooth 3D interactions
-2. **Open-Meteo as primary weather API**: Free, no API key required — reduces setup friction for contributors
-3. **Chart.js over Recharts**: Greater customization options for forecast visualizations
-4. **CSS Variables**: Native dark mode support and themed map colors without CSS-in-JS overhead
-5. **Bottom-sheet pattern on mobile**: Touch-friendly swipe gestures instead of modal dialogs
+1. **Mapbox GL over Leaflet**: globe projection, custom layer styling, and smooth 3D interactions — at the cost of a 1.6 MB chunk, which is mitigated by lazy-loading.
+2. **`React.lazy` over manual `rollupOptions.manualChunks`**: route-aware code splitting that mirrors the user journey (skeleton → map → panel) instead of hand-tuning bundler config.
+3. **Open-Meteo as primary weather API**: free, no key required, zero contributor friction; OpenWeatherMap and a mock dataset cover fallback paths.
+4. **Derived advisories instead of an official alerts feed**: Open-Meteo has no alerts endpoint and weather.gov is US-only. Computing advisories from the existing payload keeps the feature global, deterministic in tests, and clearly labelled in the UI.
+5. **Chart.js over Recharts**: greater customization for forecast visualizations, with `<table class="sr-only">` data tables backing every chart for screen-reader parity.
+6. **CSS variables**: native dark mode and themed map colors without CSS-in-JS overhead.
+7. **`aria-live` status announcements via a small `useStatusAnnouncement` hook**: testable in isolation with `renderHook`, keeps announcement logic out of `App.tsx`.
+8. **Bottom-sheet pattern on mobile**: touch-friendly swipe gestures over modal dialogs.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,17 @@ An interactive weather dashboard built with React 19 and Mapbox GL. Select citie
 
 ## Features
 
-- 🌍 **Interactive Mapbox globe** — full-screen map with custom-styled land, water, and boundaries
+- 🌍 **Interactive Mapbox globe** — full-screen map with custom-styled land, water, and boundaries (lazy-loaded so the engine never blocks first paint)
 - 📍 **10 city markers** — keyboard-navigable pins with pulse animation on selection
-- 🌤️ **Real-time weather** — current conditions via Open-Meteo (free, no key required)
-- 📊 **5-day forecast charts** — temperature trends and daily breakdowns with Chart.js
-- 🌡️ **Unit toggle** — switch between °F/°C and mph/km/h
+- 🌤️ **Real-time weather** — current conditions via Open-Meteo (free, no key required) with OpenWeatherMap and offline mock fallbacks
+- 📊 **Hourly + 5-day forecast charts** — Chart.js visuals with `<table class="sr-only">` data tables for screen readers
+- 🌡️ **Rich location details** — feels-like, sunrise/sunset, daylight duration, compass wind direction, visibility, pressure, precipitation amount and chance (each with an "Unavailable" fallback)
+- 🚨 **Derived weather advisories** — client-side severity-coloured banners (severe / warning / info) computed from the existing payload, clearly labelled "Derived advisory"
+- 🖼️ **City hero banner** — lazy-loaded location image with dark gradient overlay, fixed-height container avoids CLS, errors fall back silently
+- 🌗 **Unit toggle** — switch between °F/°C and mph/km/h, persisted in localStorage
 - 📱 **Responsive bottom sheet** — swipe-to-dismiss panel on mobile with touch gestures
-- ♿ **Accessible** — ARIA labels, keyboard navigation, focus management, live regions
-- 🔗 **URL sync** — shareable city links via `?city=<id>` query params
+- ♿ **Accessible** — ARIA labels, keyboard navigation, focus management, and an `aria-live` region announcing loading / refreshing / stale / error transitions
+- 🔗 **URL sync** — shareable city links via `/city/:cityId` (legacy `?city=<id>` redirects)
 - 🔄 **Offline fallback** — graceful degradation with mock data when APIs are unavailable
 
 ## Tech Stack

--- a/progress.txt
+++ b/progress.txt
@@ -1,7 +1,7 @@
 Project: performance-teardown-demo
-Status: COMPLETE
+Status: COMPLETE (with ongoing iteration)
 
-Last Updated: 2026-03-12 15:48 EDT
+Last Updated: 2026-05-01 EDT
 
 Milestones
 [x] M1 - Project scaffold (Vite + React + TS)
@@ -9,9 +9,12 @@ Milestones
 [x] M3 - Quality checks (lint/typecheck/tests)
 [x] M4 - Vercel deploy
 [x] M5 - Portfolio case-study update
+[x] M6 - Feature surface expansion (rich details, city hero, derived advisories, a11y status)
+[x] M7 - Performance teardown: lazy-load Mapbox + MapView CSS off the critical path
+[x] M8 - Case-study refresh (CASE_STUDY.md, README, progress) post M6/M7
 
 Current Task
-- Project complete.
+- Project complete; documentation refreshed to match current feature set and bundle profile.
 
 Blockers
 - [NONE]
@@ -19,11 +22,19 @@ Blockers
 Notes
 - Live URL: https://performance-teardown-demo.vercel.app
 - Case Study: CASE_STUDY.md
-- Tests: 6 passing (Vitest + React Testing Library)
-- Bundle: 127.17 KB gzipped
+- Tests: 242 passing across 21 Vitest files (Vitest + React Testing Library)
+- Eager bundle: 239 kB raw / 77 kB gzipped (index-*.js)
+- Lazy chunks: Dashboard 208 kB / 71 kB gz, MapView 22 kB / 8 kB gz, mapbox-gl 1,666 kB / 452 kB gz
+- ~470 kB gzipped of JS+CSS removed from the LCP critical path via React.lazy + MapSkeleton
 
 Change Log
-- [2026-03-12 15:48 EDT] Created CASE_STUDY.md for portfolio use. All milestones complete.
+- [2026-05-01] Refreshed CASE_STUDY.md and README.md to reflect the current feature surface (rich details, city hero, derived advisories, a11y status announcements) and the lazy-Mapbox perf win. Updated progress notes accordingly.
+- [Earlier this cycle] PR #78 — lazy-load Mapbox + MapView CSS via React.lazy + MapSkeleton.
+- [Earlier this cycle] PR #76 — derived weather advisories with severity banners.
+- [Earlier this cycle] PR #75 — city hero banners with lazy image + gradient overlay.
+- [Earlier this cycle] PR #74 — richer current-conditions details with graceful "Unavailable" fallbacks.
+- [Earlier this cycle] PR #73 — aria-live status announcements via useStatusAnnouncement hook.
+- [2026-03-12 15:48 EDT] Created CASE_STUDY.md for portfolio use. All initial milestones complete.
 - [2026-03-12 15:46 EDT] Deployed to Vercel (production).
 - [2026-03-12 15:45 EDT] Completed M2 and M3 - Dashboard with Chart.js, Vitest tests passing.
 - [2026-03-12 15:21 EDT] Scaffolded repository and initialized tracker.


### PR DESCRIPTION
Brings the portfolio-facing docs in line with the current state of the app after this iteration cycle.

## Changes

**CASE_STUDY.md**
- Replaces the stale 63-test / 139 KB-gzipped metrics with current numbers (242 passing across 21 files; 239 kB raw / 77 kB gz eager bundle).
- Adds a Performance Teardown section with a before/after table covering the lazy-Mapbox split — ~470 kB gzipped of JS+CSS removed from the LCP critical path.
- Documents the expanded feature surface: rich location details with Unavailable fallbacks, derived weather advisories (severe/warning/info), city hero banners, hourly + 5-day chart tabs, aria-live status announcements, /city/:cityId route + legacy redirect.
- Updates Key Decisions with the rationale for React.lazy over manual chunking and for client-derived advisories over an official alerts feed (Open-Meteo has none and weather.gov is US-only).

**README.md**
- Expands the Features bullets to match the current UI and points URL sync at the /city/:cityId route.

**progress.txt**
- Refreshes metrics (242 tests, current bundle profile) and adds milestones M6/M7/M8 covering the recent feature and perf work.

## Verification
- npm test -- --run → 242 / 242 passing across 21 files.
- npm run build → clean, eager index-*.js is 239 kB raw / 77 kB gz; mapbox-gl chunk is lazy.
- grep mapbox-gl dist/assets/index-*.js → 0 matches.
- Spot-checked README and CASE_STUDY for stale numbers (127, 139 KB, 6/63 passing) — none remain in docs (e2e specs intentionally still use the legacy ?city= URL to exercise the redirect).